### PR TITLE
fixed_irreversible_reactions_kb_computation

### DIFF
--- a/src/kinetics/Kinetics.cpp
+++ b/src/kinetics/Kinetics.cpp
@@ -229,6 +229,9 @@ void Kinetics::backwardRateCoefficients(double* const p_kb)
     mp_rates->update(m_thermo);
     Map<ArrayXd>(p_kb, nReactions()) = 
         Map<const ArrayXd>(mp_rates->lnkb(), nReactions()).exp();
+        
+    for(int i=0; i < mp_rates->irrReactions().size(); ++i)
+        p_kb[mp_rates->irrReactions()[i]] = 0.0;
 }
 
 
@@ -383,6 +386,9 @@ void Kinetics::jacobianRho(double* const p_jac)
     const double* const lnkb = mp_rates->lnkb();
     for (int i = 0; i < nReactions(); ++i)
         mp_ropb[i] = std::exp(lnkb[i]);
+    
+    for(int i=0; i < mp_rates->irrReactions().size(); ++i)
+        mp_ropb[mp_rates->irrReactions()[i]] = 0.0;
     
     // Compute species concentrations (mol/m^3)
     const double mix_conc = m_thermo.numberDensity() / NA;

--- a/src/kinetics/RateManager.cpp
+++ b/src/kinetics/RateManager.cpp
@@ -200,16 +200,22 @@ void RateManager::addRate(const size_t rxn, const Reaction& reaction)
 {    
     m_rate_groups.addRateCoefficient<ForwardGroup>(rxn, reaction.rateLaw());
     
-    // Make use of forward computation when possible
-    if (is_same<ForwardGroup, ReverseGroup>::value)
-        m_to_copy.push_back(rxn);
-    else
-        // Evaluate at the reverse temperature
-        // note: mp_lnkff+(rxn+m_nr) = mp_lnkfb+rxn
-        m_rate_groups.addRateCoefficient<ReverseGroup>(
-            rxn+m_nr, reaction.rateLaw());
-    
-    m_rate_groups.addReaction<ReverseGroup>(rxn, reaction);
+    if (reaction.isReversible()) {
+        
+        // Make use of forward computation when possible
+        if (is_same<ForwardGroup, ReverseGroup>::value)
+            m_to_copy.push_back(rxn);
+        else
+            // Evaluate at the reverse temperature
+            // note: mp_lnkff+(rxn+m_nr) = mp_lnkfb+rxn
+            m_rate_groups.addRateCoefficient<ReverseGroup>(
+                rxn+m_nr, reaction.rateLaw());
+        
+        m_rate_groups.addReaction<ReverseGroup>(rxn, reaction);
+        
+    } else {
+        m_irr.push_back(rxn);
+    }
 }
 
 //==============================================================================

--- a/src/kinetics/RateManager.h
+++ b/src/kinetics/RateManager.h
@@ -71,6 +71,13 @@ public:
      * forward temperature.
      */
     const double* const lnkb() { return mp_lnkb; }
+    
+    /**
+     * Returns the indices of irreversible reactions.
+     */
+    const std::vector<size_t>& irrReactions() const {
+        return m_irr;
+    }
 
 private:
 
@@ -118,6 +125,9 @@ private:
     /// Stores the indices for which the forward and reverse temperature
     /// evaluations are equal
     std::vector<size_t> m_to_copy;
+    
+    /// Stores the indices of non-reversible reactions
+    std::vector<size_t> m_irr;
 };
 
 

--- a/tests/test_reaction_mechanism.cpp
+++ b/tests/test_reaction_mechanism.cpp
@@ -190,12 +190,15 @@ void TestMechanism::setState(Array densities, double Th, double Tv)
     m_keq(2) = ONEATM / (RU * Tv) * std::exp(-2.0*m_wdot(2) + m_wdot(6));
     m_keq(4) = std::exp(-m_wdot(4) - m_wdot(0) + m_wdot(1) + m_wdot(2));
 
-    m_kb(0) = m_A(0) * Th / m_keq(0);
-    m_kb(1) = m_A(1) * Th / m_keq(1);
-    m_kb(2) = m_A(2) * Tv / m_keq(2);
-    m_kb(3) = m_A(3) * Th / m_keq(3);
-    m_kb(4) = m_A(4) * Tv / m_keq(4);
-
+    m_kb.setZero();
+    if (m_reversible) {
+        m_kb(0) = m_A(0) * Th / m_keq(0);
+        m_kb(1) = m_A(1) * Th / m_keq(1);
+        m_kb(2) = m_A(2) * Tv / m_keq(2);
+        m_kb(3) = m_A(3) * Th / m_keq(3);
+        m_kb(4) = m_A(4) * Tv / m_keq(4);
+    }
+    
     for (int i = 0; i < 7; ++i)
         m_wdot[i] = densities[i] / m_Mw[i];
     double M = m_wdot.tail(6).sum();
@@ -234,16 +237,11 @@ bool stillPermuting(std::vector<double>& x)
     return permuting;
 }
 
-/**
- * Tests if the TestMechanism evaluation matches Kinetics.
- */
-TEST_CASE
-(
-    "Test mechanism is evaluated correctly",
-    "[kinetics]"
-)
+
+
+void testMech(bool isRev)
 {
-    TestMechanism mech;
+    TestMechanism mech(isRev);
     SharedPtr<Mixture> mix = mech.representativeMixture();
 
     // Create a vector of "densities" in sorted order
@@ -286,4 +284,17 @@ TEST_CASE
         }
     } while (stillPermuting(rho));
 
+}
+
+/**
+ * Tests if the TestMechanism evaluation matches Kinetics.
+ */
+TEST_CASE
+(
+    "Test mechanism is evaluated correctly",
+    "[kinetics]"
+)
+{
+    testMech(true);
+    testMech(false);
 }


### PR DESCRIPTION
To verify it quickly, you may run " mppequil -m 0 -r 0,1 air5 " for a mechanism file with several reversible reactions (e.g. N2+M=2N+M), then rerun with one reaction made irreversible (e.g. N2+M=>2N+M). The results should be identical except for that irreversible reaction (kb should be equal to 0).