### PR TITLE
Fixing small bug in RamshawDiffMat.cpp

### DIFF
--- a/src/transport/CollisionDB.cpp
+++ b/src/transport/CollisionDB.cpp
@@ -236,7 +236,7 @@ const ArrayXd& CollisionDB::nDij()
 
 //==============================================================================
 
-const ArrayXd& CollisionDB::Dim()
+const ArrayXd& CollisionDB::Dim(bool include_one_minus_x)
 {
     const int ns = nSpecies();
     const int nh = m_nh;
@@ -260,9 +260,14 @@ const ArrayXd& CollisionDB::Dim()
         }
     }
 
-    // Compute (1-X_i) as sum_j!=i X_j for better accuracy
-    for (int i = 0; i < ns; ++i)
-        m_Dim(i) = (X.head(i).sum() + X.tail(ns-i-1).sum()) / m_Dim(i);
+    if (include_one_minus_x) {
+        // Compute (1-X_i) as sum_j!=i X_j for better accuracy
+        for (int i = 0; i < ns; ++i)
+            m_Dim(i) = (X.head(i).sum() + X.tail(ns-i-1).sum()) / m_Dim(i);
+    }
+    else {
+        m_Dim = 1.0 / m_Dim;
+    }
 
     // Remove number density and return
     return (m_Dim /= m_thermo.numberDensity());

--- a/src/transport/CollisionDB.h
+++ b/src/transport/CollisionDB.h
@@ -163,8 +163,11 @@ public:
     /**
      * Returns the average diffusion coefficients.
      * \f[ D_{im} = \frac{(1-x_i)}{\sum_{j\ne i}x_j/\mathscr{D}_{ij}} \f]
+     * If include_one_minus_x is false, the \f$1-x_i\f$ term taken to be 1.
+     * This is sometimes useful when only the partial evaluation of Dim is 
+     * required.
      */
-    const Eigen::ArrayXd& Dim();
+    const Eigen::ArrayXd& Dim(bool include_one_minus_x = true);
 
     /// Returns the \f$\Lambda^{01}_{ei}\f$ array.
     const Eigen::ArrayXd& L01ei();

--- a/src/transport/RamshawDiffMat.cpp
+++ b/src/transport/RamshawDiffMat.cpp
@@ -65,12 +65,12 @@ public:
         Eigen::Map<const Eigen::ArrayXd> X = m_collisions.X();
         Eigen::Map<const Eigen::ArrayXd> Y = m_collisions.Y();
 
-        // Compute average diffusion coefficients
-        const Eigen::ArrayXd& Dim = m_collisions.Dim();
+        // Compute average diffusion coefficients without 1-X(j) term
+        const Eigen::ArrayXd& Dim = m_collisions.Dim(false);
 
         // Form the matrix
         for (int j = 0; j < ns; ++j) {
-            m_Dij.col(j).fill(-Y[j]/X[j]*(1.-Y[j])/(1.-X[j])*Dim(j));
+            m_Dij.col(j).fill(-Y[j]/X[j]*(1.-Y[j])*Dim(j));
             m_Dij(j,j) -= m_Dij(j,j)/Y[j];
         }
 


### PR DESCRIPTION
This solves a small issue in the computation of the Ramshaw diffusion matrix when there is only one species present in a mixture (prevents divide by zero), referenced in #58.