### PR TITLE
Issue 74: Bugs/segfault in jacobianRho()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ common_sources: &all_sources
   # - llvm-toolchain-trusty-4.0
   # - llvm-toolchain-trusty-5.0
   # - llvm-toolchain-trusty-6.0
-  # - llvm-toolchain-trusty-7
-  # - llvm-toolchain-trusty-8
+  - llvm-toolchain-trusty-7
+  - llvm-toolchain-trusty-8
 
 
 build_both: &build_both

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,13 @@ stages:
 
 common_sources: &all_sources
   - ubuntu-toolchain-r-test
-  - llvm-toolchain-trusty
-  - llvm-toolchain-trusty-3.9
-  - llvm-toolchain-trusty-4.0
-  - llvm-toolchain-trusty-5.0
-  - llvm-toolchain-trusty-6.0
-  - llvm-toolchain-trusty-7
-  - llvm-toolchain-trusty-8
+  # - llvm-toolchain-trusty
+  # - llvm-toolchain-trusty-3.9
+  # - llvm-toolchain-trusty-4.0
+  # - llvm-toolchain-trusty-5.0
+  # - llvm-toolchain-trusty-6.0
+  # - llvm-toolchain-trusty-7
+  # - llvm-toolchain-trusty-8
 
 
 build_both: &build_both

--- a/src/kinetics/JacobianManager.h
+++ b/src/kinetics/JacobianManager.h
@@ -346,7 +346,22 @@ public:
     ReactionStoich(JacStoichBase* reacs, JacStoichBase* prods)
         : m_reacs(*static_cast<Reactants*>(reacs)), 
           m_prods(*static_cast<Products*>(prods))
-    { }
+    { 
+        // Save indices and reaction stoichiometry of the involved species
+        for (int i = 0; i < Reactants::nSpecies(); ++i)
+            m_index_stoich.emplace_back(m_reacs(i), -m_reacs[i]);
+        
+        for (int i = 0; i < Products::nSpecies(); ++i) {
+            int k = -1;
+            for (int j = 0; j < Reactants::nSpecies(); ++j)
+                if (m_index_stoich[j].first == m_prods(i)) k = j;
+            
+            if (k == -1)
+                m_index_stoich.emplace_back(m_prods(i), m_prods[i]);
+            else
+                m_index_stoich[k].second += m_prods[i];
+        }
+    }
     
     /**
      * Destructor.
@@ -368,7 +383,7 @@ protected:
     
     Reactants m_reacs;
     Products  m_prods;
-    
+    std::vector< std::pair<int, int> > m_index_stoich;
 };
 
 
@@ -397,7 +412,8 @@ public:
 
     using ReactionStoich<Reactants, Products>::m_reacs;
     using ReactionStoich<Reactants, Products>::m_prods;
-    
+    using ReactionStoich<Reactants, Products>::m_index_stoich;
+
     /**
      * Constructor.
      */

--- a/src/kinetics/Kinetics.cpp
+++ b/src/kinetics/Kinetics.cpp
@@ -160,7 +160,7 @@ void Kinetics::closeReactions(const bool validate_mechanism)
     // Allocate work arrays
     mp_ropf  = new double [nReactions()];
     mp_ropb  = new double [nReactions()];
-    mp_rop   = new double [nReactions()];
+    mp_rop   = new double [std::max(m_thermo.nSpecies(), (int) nReactions())];
     mp_wdot  = new double [m_thermo.nSpecies()];
     
 }
@@ -371,8 +371,7 @@ void Kinetics::jacobianRho(double* const p_jac)
 {
     // Special case of no reactions
     if (nReactions() == 0) {
-        for (int i = 0; i < m_thermo.nSpecies()*m_thermo.nSpecies(); ++i)
-            p_jac[i] = 0.0;
+        std::fill(p_jac, p_jac + m_thermo.nSpecies()*m_thermo.nSpecies(), 0.0);
         return;
     }
 

--- a/src/kinetics/Kinetics.cpp
+++ b/src/kinetics/Kinetics.cpp
@@ -371,29 +371,17 @@ void Kinetics::jacobianRho(double* const p_jac)
 {
     // Special case of no reactions
     if (nReactions() == 0) {
-        std::fill(p_jac, p_jac + m_thermo.nSpecies()*m_thermo.nSpecies(), 0.0);
+        std::fill(p_jac, p_jac + m_thermo.nSpecies()*m_thermo.nSpecies(), 0);
         return;
     }
 
-    // Update reaction rate coefficients
-    mp_rates->update(m_thermo);
-    
-    const double* const lnkf = mp_rates->lnkf();
-    for (int i = 0; i < nReactions(); ++i)
-        mp_ropf[i] = std::exp(lnkf[i]);
-    
-    const double* const lnkb = mp_rates->lnkb();
-    for (int i = 0; i < nReactions(); ++i)
-        mp_ropb[i] = std::exp(lnkb[i]);
-    
-    for(int i=0; i < mp_rates->irrReactions().size(); ++i)
-        mp_ropb[mp_rates->irrReactions()[i]] = 0.0;
-    
+    forwardRateCoefficients(mp_ropf);
+    backwardRateCoefficients(mp_ropb);
+
     // Compute species concentrations (mol/m^3)
-    const double mix_conc = m_thermo.numberDensity() / NA;
-    const double* const p_x = m_thermo.X();
-    for (int i = 0; i < m_thermo.nSpecies(); ++i)
-        mp_rop[i] = p_x[i] * mix_conc;
+    Map<ArrayXd>(mp_rop, m_thermo.nSpecies()) =
+        (m_thermo.numberDensity() / NA) *
+        Map<const ArrayXd>(m_thermo.X(), m_thermo.nSpecies());
     
     // Compute the Jacobian matrix
     m_jacobian.computeJacobian(mp_ropf, mp_ropb, mp_rop, p_jac);


### PR DESCRIPTION
This PR fixes #74.  Namely, it solves 3 issues found in the Kinetics::jacobianRho() function:
1. Fixes the cause of a segfault when the number of reactions is less than the number species,
2. Removes electrons from consideration as a third-body for third-body reactions, and
3. Removes redundant Jacobian contribution from third-body species in reactions that are not explicitly third-body reactions (e.x.: N2 + N = N + N + N).

In addition to fixing these bugs, the `test_reaction_mechanism.cpp` file is updated to ensure the Jacobian is tested as well against a hard-coded mechanism implementation.

Note that this is a draft for now because the proposed fixes are slow.  A few optimizations will be put in place before allowing this to be merged.