### PR TITLE
94 bug fix

### DIFF
--- a/src/thermo/Thermodynamics.cpp
+++ b/src/thermo/Thermodynamics.cpp
@@ -524,7 +524,6 @@ double Thermodynamics::mixtureEquilibriumCpMole()
         sum3 += mp_work2[j];               // sum_j N_j
         sum4 += mp_work2[j]*mp_work1[j];   // sum_j N_j*H_j/RT
     }
-    std::cout << sum3 << ' ' << sum4 << std::endl;
 
     // Compute the Cp vector
     speciesCpOverR(mp_work1);

--- a/src/thermo/Thermodynamics.cpp
+++ b/src/thermo/Thermodynamics.cpp
@@ -495,6 +495,9 @@ double Thermodynamics::mixtureFrozenCpMass() const
 
 double Thermodynamics::mixtureEquilibriumCpMole()
 {
+    if (nSpecies() == 1)
+        return mixtureFrozenCpMole();
+    
     const double T = this->T();
     
     // Compute species enthalpies and dg/dT
@@ -521,6 +524,7 @@ double Thermodynamics::mixtureEquilibriumCpMole()
         sum3 += mp_work2[j];               // sum_j N_j
         sum4 += mp_work2[j]*mp_work1[j];   // sum_j N_j*H_j/RT
     }
+    std::cout << sum3 << ' ' << sum4 << std::endl;
 
     // Compute the Cp vector
     speciesCpOverR(mp_work1);
@@ -536,6 +540,9 @@ double Thermodynamics::mixtureEquilibriumCpMole()
 
 double Thermodynamics::mixtureEquilibriumCpMass()
 {
+    if (nSpecies() == 1)
+        return mixtureFrozenCpMass();
+
     const double T = this->T();
 
     // Compute species enthalpies and dg/dT

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ configure_file(Configuration.h.in Configuration.h)
 
 add_executable(run_tests 
     run_tests.cpp
+    test_bug_94.cpp
     test_collision_integrals.cpp
     test_comparisons.cpp
     test_convert.cpp

--- a/tests/test_bug_94.cpp
+++ b/tests/test_bug_94.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 von Karman Institute for Fluid Dynamics (VKI)
+ *
+ * This file is part of MUlticomponent Thermodynamic And Transport
+ * properties for IONized gases in C++ (Mutation++) software package.
+ *
+ * Mutation++ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Mutation++ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with Mutation++.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include "mutation++.h"
+#include "TestMacros.h"
+#include <catch.hpp>
+
+using namespace Mutation;
+using namespace Catch;
+
+
+TEST_CASE(
+    "Bug #94 fix: 1 species equilibrium cp doesn't NaN",
+    "[bugs][thermodynamics]"
+)
+{
+    MixtureOptions opts;
+    opts.setSpeciesDescriptor("NH3");
+    opts.setStateModel("Equil");
+    Mixture mix(opts);                       
+
+    double T = 1548;
+    double P = 1106507.818257603;
+    mix.setState(&P, &P, 1);
+
+    double cp_mole = mix.mixtureEquilibriumCpMole();
+    CHECK(!isnan(cp_mole));
+    
+    double cp_mass = mix.mixtureEquilibriumCpMass();
+    CHECK(!isnan(cp_mass));
+
+    double cp_NH3;
+    mix.speciesCpOverR(&cp_NH3);
+    CHECK(cp_mole == cp_NH3 * RU);
+    CHECK(cp_mass == cp_NH3 * RU / mix.speciesMw(0));
+}


### PR DESCRIPTION
Solves #94 - FPE or NaN when computing equilibrium cp for a single species mixture.  A new test has been also added to ensure the problem does not come back.