### PR TITLE
Fixes #115.

### DIFF
--- a/src/transport/Transport.cpp
+++ b/src/transport/Transport.cpp
@@ -282,7 +282,7 @@ double Transport::butlerBrokawThermalConductivity()
     const Eigen::MatrixXd& E = m_thermo.elementMatrix();
 
     // Find the elements
-    Eigen::VectorXd ei(ne);
+    Eigen::VectorXi ei(ne);
     for (int i = 0; i < ne; ++i)
         ei(i) = m_thermo.speciesIndex(m_thermo.elementName(i));
 


### PR DESCRIPTION
Need to use type definition VectorXi for the array of element indices
instead of the VectorXd, which is for double.