### PR TITLE
Fixing bug #120

### DIFF
--- a/src/general/mppequil.cpp
+++ b/src/general/mppequil.cpp
@@ -912,11 +912,17 @@ int main(int argc, char** argv)
                 } else if (name == "omega") {
                     mix.netProductionRates(species_values);
                 } else if (name == "Omega11") {
-                    Map<ArrayXd>(species_values,mix.nSpecies()) =
-                        (ArrayXd(mix.nSpecies()) << mix.collisionDB().Q11ee(),mix.collisionDB().Q11ii()).finished();
+                    int k = mix.hasElectrons() ? 1 : 0;
+                    if (k == 1)
+                        species_values[0] = mix.collisionDB().Q11ee();
+                    Map<ArrayXd>(species_values+k, mix.nHeavy()) =
+                        mix.collisionDB().Q11ii();
                 } else if (name == "Omega22") {
-                    Map<ArrayXd>(species_values,mix.nSpecies()) =
-                        (ArrayXd(mix.nSpecies()) << mix.collisionDB().Q22ee(),mix.collisionDB().Q22ii()).finished();
+                    int k = mix.hasElectrons() ? 1 : 0;
+                    if (k == 1)
+                        species_values[0] = mix.collisionDB().Q22ee();
+                    Map<ArrayXd>(species_values+k, mix.nHeavy()) =
+                        mix.collisionDB().Q22ii();
                 } else if (name == "Chi^h") {
                     mix.heavyThermalDiffusionRatios(species_values);
                 } else if (name == "Dm") {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -66,3 +66,8 @@ ParseAndAddCatchTests(run_tests)
 
 add_executable(update_comparison update_comparison.cpp)
 target_link_libraries(update_comparison mutation++)
+
+add_test(
+    NAME bugfix_120
+    COMMAND mppequil -T 300 -P 101325 -s 15,16 --species-list "O O2"
+)


### PR DESCRIPTION
This fixes bug #120 which should have occurred whenever pure species collision integrals were requested in mppequil with a mixture that does not have electrons.  A new test is also added to ensure the bug is caught in the future if it is mistakenly added back.