### PR TITLE
Bump version in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ cmake_policy(SET CMP0048 NEW)
 set(CMAKE_CXX_STANDARD 11)
 
 project(mutation++
-    VERSION 0.3.2
+    VERSION 1.0.1
     LANGUAGES CXX
 )
 


### PR DESCRIPTION
This should probably automated: if tests passes and you're tagging, then Github actions automatically bump the version (and merge it).

In any case this fix the actual problem, you should tag also to `v1.0.1` so that package managers can get the right version