### PR TITLE
Adding API Documentation page

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2,4 +2,4 @@
 
 # API Documentation
 
-Oops!  It looks like we are still working on hosting the documentation.  In the meantime, you can [build the API docs yourself using Doxygen](installation.md).
+Oops!  It looks like we are still working on hosting the documentation.  In the meantime, you can [build the API docs yourself using Doxygen](installation.md#build-api-docs).

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,5 @@
+<a id="top"></a>
+
+# API Documentation
+
+Oops!  It looks like we are still working on hosting the documentation.  In the meantime, you can [build the API docs yourself using Doxygen](installation.md).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -99,7 +99,6 @@ appropriate file.  Mixture files may also be placed in the local directory in
 which you are calling any Mutation++ tool.
 
 
-<a id="docs"></a>
 ## Build API Docs
 If you are interested in building the API documentation for Mutation++ locally, then be sure to have [Doxygen](https://www.doxygen.nl/index.html) installed on your computer and run
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -97,3 +97,14 @@ which will display a help message.  To modify or create new mixtures, go to the
 `data/mixtures` folder in your mutation++ directory and open or create the
 appropriate file.  Mixture files may also be placed in the local directory in
 which you are calling any Mutation++ tool.
+
+
+<a id="docs"></a>
+## Build API Docs
+If you are interested in building the API documentation for Mutation++ locally, then be sure to have [Doxygen](https://www.doxygen.nl/index.html) installed on your computer and run
+
+```
+make docs
+```
+
+from the `build` directory.  Once done, open the `docs/html/index.html` file using your favorite web browser to see a full listing of all the classes and methods available in the library.


### PR DESCRIPTION
This page just redirects to a newly created section in the installation instructions for building the docs locally.  In the future, the link should instead take us to our hosted API documentation which would be generated at each new PR merge.