### PR TITLE
Updating test related to bug #139 and improving cmake script

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,33 +24,8 @@ cmake_minimum_required(VERSION 2.6)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 configure_file(Configuration.h.in Configuration.h)
 
-add_executable(run_tests 
-    run_tests.cpp
-    test_bug_94.cpp
-    test_collision_integrals.cpp
-    test_comparisons.cpp
-    test_convert.cpp
-    test_diffusion_matrix.cpp
-    test_dXidT.cpp
-    test_energies.cpp
-    test_errors.cpp
-    test_gsi_mass.cpp
-    test_gsi_mass_energy.cpp
-    test_gsi_rates.cpp
-    test_mixtures.cpp
-    test_reactions.cpp
-    test_reaction_mechanism.cpp
-    test_reaction_rates.cpp
-    test_set_state.cpp
-    test_species.cpp
-    test_stefan_maxwell.cpp
-    test_thermal_diff_ratios.cpp
-    test_thermodb.cpp
-    test_transfer_source.cpp
-    test_utilities.cpp
-    test_wdot.cpp
-    test_levels.cpp
-)
+file(GLOB test_sources "test_*.cpp")
+add_executable(run_tests run_tests.cpp ${test_sources})
 target_link_libraries(run_tests 
     PRIVATE
         mutation++

--- a/tests/test_set_state.cpp
+++ b/tests/test_set_state.cpp
@@ -48,8 +48,10 @@ TEST_CASE("setState converts rho*Em to Tm and vice a versa",
         const int nt = mix.nEnergyEqns();
 
         VectorXd rhoi(ns);
-        VectorXd tmps1(nt);
-        VectorXd tmps2(nt);
+        VectorXd T1(nt);
+        VectorXd T2(nt);
+        VectorXd e1(nt);
+        VectorXd e2(nt);
 
         EQUILIBRATE_LOOP
         (
@@ -59,29 +61,36 @@ TEST_CASE("setState converts rho*Em to Tm and vice a versa",
 
             // Compute a randomly perturbed temperature vector T +- 500K
             for (int i = 0; i < nt; ++i)
-                tmps1[i] = double(rand()) / RAND_MAX * 1000.0 - 500.0 + T;
+                T1[i] = double(rand()) / RAND_MAX * 1000.0 - 500.0 + T;
 
             // Set the state with the densities and perturbed temperatures
-            mix.setState(rhoi.data(), tmps1.data(), t_var_set);
+            mix.setState(rhoi.data(), T1.data(), t_var_set);
 
             // Check that explicitly set properties still match
-            mix.getTemperatures(tmps2.data());
+            mix.getTemperatures(T2.data());
             for (int i = 0; i < nt; ++i)
-                CHECK(tmps1[i] == Approx(tmps2[i]));
+                CHECK(T1[i] == Approx(T2[i]));
+            
             CHECK(rho == Approx(mix.density()));
 
             // Get the energy vector
-            mix.mixtureEnergies(tmps2.data());
-            tmps2 *= rho;
+            mix.mixtureEnergies(e1.data());
+            e1 *= rho;
 
             // Set the state of the mixture based on the energies
-            mix.setState(rhoi.data(), tmps2.data(), e_var_set);
+            mix.setState(rhoi.data(), e1.data(), e_var_set);
 
             // Check that implicitly set properties still match
-            mix.getTemperatures(tmps2.data());
+            mix.getTemperatures(T2.data());
             for (int i = 0; i < nt; ++i)
-                CHECK(tmps1[i] ==  Approx(tmps2[i]));
+                CHECK(T2[i] ==  Approx(T2[i]));
+            
             CHECK(rho == Approx(mix.density()));
+
+            mix.mixtureEnergies(e2.data());
+            e2 *= rho;
+            for (int i = 0; i < nt; ++i)
+                CHECK(e1[i] ==  Approx(e2[i]));
         )
     )
 }


### PR DESCRIPTION
- Add a check that mixture energies are correctly reproduced when calling setState() with species densities and mixture energy densities.  This is a first pass at investigating #139. 
- Modified the cmake script for compiling tests to automatically compile the run_tests with any files matching the name `test_*.cpp`.  This is just to make it easier to add tests in the future.