### PR TITLE
This commit addresses issues #144, 10/14

### DIFF
--- a/src/fortran/cwrapper.cpp
+++ b/src/fortran/cwrapper.cpp
@@ -142,6 +142,12 @@ void NAME_MANGLE(species_name)(int* index, F_STRING species, F_STRLEN species_le
 }
 
 //==============================================================================
+bool NAME_MANGLE(has_electrons)()
+{
+    return p_mix->hasElectrons();
+}
+
+//==============================================================================
 double NAME_MANGLE(mixture_mw)()
 {
     return p_mix->mixtureMw();
@@ -361,6 +367,16 @@ void NAME_MANGLE(heavy_thermal_diffusion_ratios) (double* const pk)
 }
 
 //==============================================================================
+//void NAME_MANGLE(heavy_thermal_diffusion_ratios) (double* const pk)
+//{
+double NAME_MANGLE(electron_thermal_diffusionratios)()
+{ 
+   return p_mix->electronThermalDiffusionRatio();
+}
+//    p_mix->heavyThermalDiffusionRatios(pk);
+//}
+
+//==============================================================================
 double NAME_MANGLE(equilibrium_thermal_conductivity)()
 {
     return p_mix->equilibriumThermalConductivity();
@@ -373,15 +389,33 @@ double NAME_MANGLE(heavy_thermal_conductivity)()
 }
 
 //==============================================================================
+double NAME_MANGLE(rotational_thermal_conductivity)()
+{
+    return p_mix->rotationalThermalConductivity();
+}
+
+//==============================================================================
+double NAME_MANGLE(vibrational_thermal_conductivity)()
+{
+    return p_mix->vibrationalThermalConductivity();
+}
+
+//==============================================================================
+double NAME_MANGLE(electronic_thermal_conductivity)()
+{
+    return p_mix->electronicThermalConductivity();
+}
+
+//==============================================================================
 double NAME_MANGLE(electron_thermal_conductivity)()
 {
     return p_mix->electronThermalConductivity();
 }
 
 //==============================================================================
-double NAME_MANGLE(internal_thermal_conductivity)(double T)
+double NAME_MANGLE(internal_thermal_conductivity)(double* T)
 {
-    return p_mix->internalThermalConductivity(T);
+    return p_mix->internalThermalConductivity(*T);
 }
 
 //==============================================================================

--- a/src/fortran/cwrapper.cpp
+++ b/src/fortran/cwrapper.cpp
@@ -409,7 +409,7 @@ double NAME_MANGLE(electron_thermal_conductivity)()
 }
 
 //==============================================================================
-double NAME_MANGLE(internal_thermal_conductivity)(double* T)
+double NAME_MANGLE(internal_thermal_conductivity)(const double* const T)
 {
     return p_mix->internalThermalConductivity(*T);
 }

--- a/src/fortran/cwrapper.cpp
+++ b/src/fortran/cwrapper.cpp
@@ -367,14 +367,10 @@ void NAME_MANGLE(heavy_thermal_diffusion_ratios) (double* const pk)
 }
 
 //==============================================================================
-//void NAME_MANGLE(heavy_thermal_diffusion_ratios) (double* const pk)
-//{
-double NAME_MANGLE(electron_thermal_diffusionratios)()
+double NAME_MANGLE(electron_thermal_diffusion_ratios)()
 { 
    return p_mix->electronThermalDiffusionRatio();
 }
-//    p_mix->heavyThermalDiffusionRatios(pk);
-//}
 
 //==============================================================================
 double NAME_MANGLE(equilibrium_thermal_conductivity)()

--- a/src/fortran/cwrapper.h
+++ b/src/fortran/cwrapper.h
@@ -401,7 +401,7 @@ double NAME_MANGLE(electron_thermal_conductivity)();
 /**
  * Returns the internal energy thermal conductivity using Euken's formulas.
  */
-double NAME_MANGLE(internal_thermal_conductivity)(double *const T);
+double NAME_MANGLE(internal_thermal_conductivity)(const double* const T);
 
 /**
  * Returns the reactive thermal conductivity which accounts for reactions

--- a/src/fortran/cwrapper.h
+++ b/src/fortran/cwrapper.h
@@ -361,7 +361,7 @@ void NAME_MANGLE(heavy_thermal_diffusion_ratios)(double* const pk);
 /**
  * Returns the Isotropic electron thermal diffusion ratio. 
  */
-double NAME_MANGLE(electron_thermal_diffusionratios)();
+double NAME_MANGLE(electron_thermal_diffusion_ratios)();
 
 /**
  * Returns the mixture thermal conductivity for a mixture in thermochemical
@@ -401,7 +401,7 @@ double NAME_MANGLE(electron_thermal_conductivity)();
 /**
  * Returns the internal energy thermal conductivity using Euken's formulas.
  */
-double NAME_MANGLE(internal_thermal_conductivity)(double* T);
+double NAME_MANGLE(internal_thermal_conductivity)(double *const T);
 
 /**
  * Returns the reactive thermal conductivity which accounts for reactions

--- a/src/fortran/cwrapper.h
+++ b/src/fortran/cwrapper.h
@@ -127,6 +127,11 @@ void NAME_MANGLE(species_name)(
     int* index, F_STRING species, F_STRLEN species_length);
 
 /**
+ * Returns true if the gas has electrons.
+ */
+bool NAME_MANGLE(has_electrons)();
+
+/**
  * Returns the mixture molecular weight in kg/mol.
  */
 double NAME_MANGLE(mixture_mw)();
@@ -354,6 +359,11 @@ void NAME_MANGLE(frozen_thermal_conductivity)(double* const lambda);
 void NAME_MANGLE(heavy_thermal_diffusion_ratios)(double* const pk);
 
 /**
+ * Returns the Isotropic electron thermal diffusion ratio. 
+ */
+double NAME_MANGLE(electron_thermal_diffusionratios)();
+
+/**
  * Returns the mixture thermal conductivity for a mixture in thermochemical
  * equilibrium.
  */
@@ -366,6 +376,24 @@ double NAME_MANGLE(equilibrium_thermal_conductivity)();
 double NAME_MANGLE(heavy_thermal_conductivity)();
 
 /**
+ * Returns the  rotational thermal conductivity using the 
+ * set algorithm.
+ */
+double NAME_MANGLE(rotational_thermal_conductivity)();
+
+/**
+ * Returns the vibrational thermal conductivity using the 
+ * set algorithm.
+ */
+double NAME_MANGLE(vibrational_thermal_conductivity)();
+
+/**
+ * Returns the electronic thermal conductivity using the 
+ * set algorithm.
+ */
+double NAME_MANGLE(electronic_thermal_conductivity)();
+
+/**
  * Returns the electron translational thermal conductivity.
  */
 double NAME_MANGLE(electron_thermal_conductivity)();
@@ -373,7 +401,7 @@ double NAME_MANGLE(electron_thermal_conductivity)();
 /**
  * Returns the internal energy thermal conductivity using Euken's formulas.
  */
-double NAME_MANGLE(internal_thermal_conductivity)(double T);
+double NAME_MANGLE(internal_thermal_conductivity)(double* T);
 
 /**
  * Returns the reactive thermal conductivity which accounts for reactions

--- a/src/fortran/cwrapper_interface.f90
+++ b/src/fortran/cwrapper_interface.f90
@@ -105,7 +105,8 @@ module mutationpp
         real(kind=8) function mpp_electron_thermal_conductivity()
         end function
 
-        real(kind=8) function mpp_internal_thermal_conductivity()
+        real(kind=8) function mpp_internal_thermal_conductivity(T)
+            real(kind=8), intent(in) :: T
         end function
 
         real(kind=8) function mpp_reactive_thermal_conductivity()
@@ -113,7 +114,21 @@ module mutationpp
    
         real(kind=8) function mpp_sigma()
         end function
+
+        logical function mpp_has_electrons()
+        end function
+
+        real(kind=8) function mpp_rotational_thermal_conductivity()
+        end function
+
+        real(kind=8) function mpp_vibrational_thermal_conductivity()
+        end function
+
+        real(kind=8) function mpp_electronic_thermal_conductivity()
+        end function
         
+        real(kind=8) function mpp_electron_thermal_diffusionratios()
+        end function
     end interface
 
 end module mutationpp

--- a/src/fortran/cwrapper_interface.f90
+++ b/src/fortran/cwrapper_interface.f90
@@ -127,7 +127,7 @@ module mutationpp
         real(kind=8) function mpp_electronic_thermal_conductivity()
         end function
         
-        real(kind=8) function mpp_electron_thermal_diffusionratios()
+        real(kind=8) function mpp_electron_thermal_diffusion_ratios()
         end function
     end interface
 


### PR DESCRIPTION
I have added the isotropic electron thermal diffusion ratios in the fortran folder of the source code. Georgios helped me in adding those functions to the cwrapper files. 