### PR TITLE
Redesign of Millikan-White model classes and OmegaVT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ cmake_policy(SET CMP0048 NEW)
 set(CMAKE_CXX_STANDARD 14)
 
 project(mutation++
-    VERSION 1.0.6
+    VERSION 1.1.0
     LANGUAGES CXX
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,10 +29,10 @@
 #
 cmake_minimum_required(VERSION 3.5)
 cmake_policy(SET CMP0048 NEW)
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 
 project(mutation++
-    VERSION 1.0.5
+    VERSION 1.0.6
     LANGUAGES CXX
 )
 

--- a/docs/bibliography.bib
+++ b/docs/bibliography.bib
@@ -32,6 +32,19 @@
     pages = {616}
 }
 
+@techreport{Gnoffo1989,
+  type = {Technical Paper},
+  title = {Conservation Equations and Physical Models for Hypersonic Air Flows in Thermal and Chemical Nonequilibrium},
+  timestamp = {2014-11-13T20:28:41Z},
+  number = {2867},
+  institution = {NASA},
+  author = {Gnoffo, Peter A. and Gupta, Roop N. and Shinn, Judy L.},
+  month = feb,
+  year = {1989},
+  pages = {65},
+  file = {19890006744.pdf:/ZoteroDB/storage/8Q62P7FU/19890006744.pdf:application/pdf}
+}
+
 @article{Laricchiuta2007,
     author = {A. Laricchiuta and G. Colonna and D. Bruno and R. Celiberto and C. Gorse and F. Pirani and M. Capitelli},
     title = {Classical transport collision integrals for a Lennard-Jones like phenomenological model potential},
@@ -60,6 +73,22 @@
 	title = {Computer Program for Calculation of Complex Chemical Equilibrium Compositions and Applications II. Users Manual and Program Description},
 	year = {1996},
 	url= {http://www.grc.nasa.gov/WWW/CEAWeb/RP-1311-P2.pdf}
+}
+
+@article{Millikan1963,
+    title = {Systematics of {{Vibrational Relaxation}}},
+    volume = {39},
+    issn = {00219606},
+    doi = {10.1063/1.1734182},
+    language = {en},
+    timestamp = {2014-11-13T08:05:38Z},
+    number = {12},
+    urldate = {2014-11-11},
+    journal = {The Journal of Chemical Physics},
+    author = {Millikan, Roger C. and White, Donald R.},
+    year = {1963},
+    pages = {3209},
+    file = {Millikan1963.pdf:/ZoteroDB/storage/4BEG6H5E/Millikan1963.pdf:application/pdf}
 }
 
 @article{Murphy1995,

--- a/src/thermo/CMakeLists.txt
+++ b/src/thermo/CMakeLists.txt
@@ -24,6 +24,7 @@ add_sources(mutation++
     ChemNonEqTTvStateModel.cpp
     Composition.cpp
     EquilStateModel.cpp
+    HarmonicOscillator.cpp
     MultiPhaseEquilSolver.cpp
     Nasa7Polynomial.cpp
     Nasa9Polynomial.cpp
@@ -41,6 +42,7 @@ add_sources(mutation++
 
 add_headers(mutation++
     Composition.h
+    HarmonicOscillator.h
     MultiPhaseEquilSolver.h
     ParticleRRHO.h
     Species.h

--- a/src/thermo/HarmonicOscillator.cpp
+++ b/src/thermo/HarmonicOscillator.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2014-2021 von Karman Institute for Fluid Dynamics (VKI)
+ *
+ * This file is part of MUlticomponent Thermodynamic And Transport
+ * properties for IONized gases in C++ (Mutation++) software package.
+ *
+ * Mutation++ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Mutation++ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with Mutation++.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include "HarmonicOscillator.h"
+#include "Utilities.h"
+
+#include <cassert>
+#include <cmath>
+#include <iterator>
+#include <sstream>
+
+namespace Mutation {
+    namespace Thermodynamics {
+
+double HarmonicOscillator::energy(double T) const
+{
+    assert(T > 0.0);
+    
+    double energy = 0.0;
+    for (auto theta: m_characteristic_temps)
+        energy += theta / (std::exp(theta/T) - 1.0);
+    return energy;
+}
+
+
+struct HarmonicOscillatorDB::Data
+{
+    Utilities::IO::XmlDocument document;
+
+    Data(std::string file_path) : document(file_path) { }
+};
+
+HarmonicOscillatorDB::HarmonicOscillatorDB() :
+    HarmonicOscillatorDB(Utilities::databaseFileName("species.xml", "thermo")) 
+{ }
+
+HarmonicOscillatorDB::HarmonicOscillatorDB(std::string file_path) :
+    m_data(std::make_shared<Data>(file_path))
+{ }
+
+HarmonicOscillator HarmonicOscillatorDB::create(
+    std::string species_name) const
+{
+    auto& root = m_data->document.root();
+    auto iter = root.findTagWithAttribute("species", "name", species_name);
+    
+    if (iter == root.end())
+        return {};
+    
+    // Find thermodynamic data
+    auto thermo_iter = iter->findTagWithAttribute("thermodynamics", "type", "RRHO");
+    if (thermo_iter == iter->end())
+        return {};
+
+    // Find vibrational temperature data
+    iter = thermo_iter->findTag("vibrational_temperatures");
+    if (iter == thermo_iter->end())
+        return {};
+
+    // Split into individual temperatures
+    std::istringstream ss(iter->text());
+    std::vector<double> temps;
+
+    std::copy(
+        std::istream_iterator<double>(ss), std::istream_iterator<double>(),
+        std::back_inserter(temps)
+    );
+
+    return { temps };
+}
+
+    } // namespace Thermodynamics
+} // namespace Mutation

--- a/src/thermo/HarmonicOscillator.h
+++ b/src/thermo/HarmonicOscillator.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2014-2021 von Karman Institute for Fluid Dynamics (VKI)
+ *
+ * This file is part of MUlticomponent Thermodynamic And Transport
+ * properties for IONized gases in C++ (Mutation++) software package.
+ *
+ * Mutation++ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Mutation++ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with Mutation++.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef THERMO_HARMONIC_OSCILLATOR_H
+#define THERMO_HARMONIC_OSCILLATOR_H
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace Mutation {
+    namespace Thermodynamics {
+
+/**
+ * Computes vibrator energy based on harmonic-oscillator model.
+ */
+class HarmonicOscillator
+{
+public:
+    /// Default oscillator with zero energy.
+    HarmonicOscillator() { }
+
+    /// Construct with list of characteristic temperatures in K.
+    template <typename Container>
+    HarmonicOscillator(const Container&);
+
+    /// Returns energy of vibrator in K at given temperature in K.
+    double energy(double T) const;
+
+    /// Convience function to access characteristic temperatures in K.
+    const std::vector<double>& characteristicTemperatures() const {
+        return m_characteristic_temps;
+    }
+
+private:
+    std::vector<double> m_characteristic_temps;
+};
+
+template <typename Container>
+HarmonicOscillator::HarmonicOscillator(const Container& temps) :
+    m_characteristic_temps(std::begin(temps), std::end(temps))
+{ }
+
+
+class HarmonicOscillatorDB
+{
+public:
+    /// Constructs the database using default file path.
+    HarmonicOscillatorDB();
+
+    /// Constructs the database using given file path.
+    HarmonicOscillatorDB(std::string file_path);
+
+    /// Creates a new harmonic oscillator associated with given species name.
+    HarmonicOscillator create(std::string species_name) const;
+
+private:
+    struct Data;
+    std::shared_ptr<Data> m_data;
+};
+
+    } // namespace Thermodynamics
+} // namespace Mutation
+
+
+#endif // THERMO_HARMONIC_OSCILLATOR_H

--- a/src/transfer/MillikanWhite.cpp
+++ b/src/transfer/MillikanWhite.cpp
@@ -42,160 +42,123 @@ using namespace Mutation::Thermodynamics;
 namespace Mutation {
     namespace Transfer {
 
-//==============================================================================
 
-MillikanWhiteVibrator::MillikanWhiteVibrator(
-    const XmlElement& node, const class Thermodynamics& thermo)
+MillikanWhiteModelData::MillikanWhiteModelData(
+    const class Thermodynamics& thermo, size_t index, double thetav
+) :
+    m_index(index),
+    m_mw(thermo.speciesMw(index)),
+    m_a(thermo.nHeavy()),
+    m_b(thermo.nHeavy())
 {
-    assert(node.tag() == "vibrator");
-        
-    // Get the name of this species
-    std::string name;
-    node.getAttribute("species", name, "must provide species name!");
-    m_index  = thermo.speciesIndex(name);
-    m_thetav = loadThetaV(name);
+    // Fill in default values
+    double theta_power = std::pow(thetav, 4.0/3.0);
+    size_t offset = (thermo.hasElectrons() ? 1 : 0);
+
+    for (size_t i = 0; i < thermo.nHeavy(); ++i)
+    {
+        double mwi = thermo.speciesMw(i+offset);
+        double mu = 1000.0*m_mw*mwi/(m_mw + mwi); // reduced mass in g/mol
+        m_a[i] = 1.16E-3*std::sqrt(mu)*theta_power;
+        m_b[i] = 0.015*std::pow(mu, 0.25);
+    }
+}
+
+
+MillikanWhiteModel::MillikanWhiteModel(const MillikanWhiteModelData& data) :
+    m_data(data) 
+{ }
+
+
+double MillikanWhiteModel::relaxationTime(
+    const Mutation::Thermodynamics::Thermodynamics& thermo) const
+{
+    // Millikan-White model for average relaxation time
+    const Eigen::Map<const Eigen::ArrayXd> Xh(
+        thermo.X()+(thermo.hasElectrons() ? 1 : 0), thermo.nHeavy());
+    const double T_fac = std::pow(thermo.T(), -1.0/3.0);
+    const double p_atm = thermo.P() / ONEATM;
+    const double tau_mw = 
+        (Xh*(m_data.a()*(T_fac - m_data.b()) - 18.42).exp()).sum() / 
+        (Xh.sum()*p_atm);
+
+    // Park correction
+    const double ni = thermo.numberDensity() * thermo.X()[m_data.speciesIndex()];
+    const double ci = std::sqrt(8*RU*thermo.T()/(PI*m_data.molecularWeight()));
+    const double tau_park = 1.0/(ni * ci * m_data.limitingCrossSection());
+
+    return tau_mw + tau_park;
+}
+
+
+struct MillikanWhiteModelDB::Data
+{
+    const class Thermodynamics& thermo;
+    XmlDocument database;
+    XmlElement::const_iterator millikan_white_xml;
+
+    Data(const class Thermodynamics& thermo, std::string file_path) :
+        thermo(thermo), database(file_path)
+    {
+        auto& root = database.root();
+        millikan_white_xml = root.findTag("Millikan-White");
+
+        if (millikan_white_xml == root.end())
+            root.parseError("Could not find Millikan-White element.");
+    }
+};
+
+
+MillikanWhiteModelDB::MillikanWhiteModelDB(
+    const class Thermodynamics& thermo
+) :
+    MillikanWhiteModelDB(thermo, databaseFileName("VT.xml", "transfer"))
+{ }
+
+
+MillikanWhiteModelDB::MillikanWhiteModelDB(
+    const class Thermodynamics& thermo, std::string file_path
+) :
+    m_data(std::make_shared<Data>(thermo, file_path))
+{ }
+
+
+MillikanWhiteModel MillikanWhiteModelDB::create(
+    std::string species_name, double theta)
+{
+    // Create default data
+    MillikanWhiteModelData data(
+        m_data->thermo, m_data->thermo.speciesIndex(species_name), theta);
+
+    // Find species in database
+    auto species_iter = m_data->millikan_white_xml->findTagWithAttribute(
+        "vibrator", "species", species_name);
     
-    // Get the limiting cross-section if available
-    node.getAttribute("omegav", m_omegav, 3.0E-21);
+    // If species not in database, return default model
+    if (species_iter == m_data->millikan_white_xml->end())
+        return { data };
     
-    const Species& vibrator = thermo.species(name);
+    // Use limiting cross section if provided
+    if (species_iter->hasAttribute("omegav"))
+        data.setLimitingCrossSection(species_iter->getAttribute<double>("omegav"));
     
     // Loop over each heavy species in thermo
-    int offset = (thermo.hasElectrons() ? 1 : 0);
-    XmlElement::const_iterator partner_iter;
-    
-    double a, b, mu;
-    for (int i = 0; i < thermo.nHeavy(); ++i) {
-        // Get collision partner
-        const Species& partner = thermo.species(i+offset);
-        
-        // Compute reduced mass of this pair
-        mu = (vibrator.molecularWeight() * partner.molecularWeight()) /
-             (vibrator.molecularWeight() + partner.molecularWeight());
-            
-        // Use a and b data from data file or use the defaults if the pair
-        // is not present in the file
-        if ((partner_iter = node.findTagWithAttribute(
-            "partner", "species", partner.name())) != node.end()) {
-            // Get a, b from parnter node
-            partner_iter->getAttribute("a", a, "must provide constant a!");
-            partner_iter->getAttribute("b", b, "must provide constant b!");
-            
-            // Add Millikan-White data for collision pair
-            m_partners.push_back(MillikanWhitePartner(a, b, mu));
-        } else {
-            if (m_thetav < 0.0) {
-                std::cout << "Error: Did not find vibrational temperature for "
-                          << name << "." << std::endl;
-                std::exit(1);
-            }
+    size_t offset = (m_data->thermo.hasElectrons() ? 1 : 0);
 
-            // Add Millikan-White data using defaults
-            m_partners.push_back(MillikanWhitePartner(mu, m_thetav));
+    for (size_t i = 0; i < m_data->thermo.nHeavy(); ++i)
+    {
+        auto partner_iter = species_iter->findTagWithAttribute(
+            "partner", "species", m_data->thermo.speciesName(i+offset));
+        
+        if (partner_iter != species_iter->end())
+        {
+            partner_iter->getAttribute("a", data.a()[i], "must provide constant a!");
+            partner_iter->getAttribute("b", data.b()[i], "must provide constant b!");
         }
     }
+
+    return { data };
 }
-
-//==============================================================================
-
-MillikanWhiteVibrator::MillikanWhiteVibrator(
-    const std::string& name, const class Thermodynamics& thermo)
-    : m_omegav(3.0E-21),
-      m_index(thermo.speciesIndex(name)),
-      m_thetav(loadThetaV(name))
-{
-    // Rely on thetav for all partners so make sure it was found
-    if (m_thetav < 0.0) {
-        std::cout << "Error: Did not find vibrational temperature for "
-                  << name << "." << std::endl;
-        std::exit(1);
-    }
-
-    const Species& vibrator = thermo.species(name);
-    
-    // Loop over each heavy species in thermo
-    int offset = (thermo.hasElectrons() ? 1 : 0);
-    double mu;
-    
-    for (int i = 0; i < thermo.nHeavy(); ++i) {
-        // Get collision partner
-        const Species& partner = thermo.species(i+offset);
-        
-        // Compute reduced mass of this pair
-        mu = (vibrator.molecularWeight() * partner.molecularWeight()) /
-             (vibrator.molecularWeight() + partner.molecularWeight());
-        
-        // Add Millikan-White data using defaults
-        m_partners.push_back(MillikanWhitePartner(mu, m_thetav));
-    }
-}
-
-//==============================================================================
-
-double MillikanWhiteVibrator::loadThetaV(const std::string& name)
-{
-    // Get the species.xml path on this computer.
-    std::string filename = databaseFileName("species.xml", "thermo");
-
-    // Now look for the species
-    XmlDocument doc(filename);
-    XmlElement::const_iterator iter = doc.root().findTagWithAttribute(
-        "species", "name", name);
-    if (iter == doc.root().end()) return -1.0;
-
-    // Look for the thermodynamic data
-    XmlElement::const_iterator thermo_iter = iter->findTagWithAttribute(
-        "thermodynamics", "type", "RRHO");
-    if (thermo_iter == iter->end()) return -1.0;
-
-    // Look for the vibrational temperature data
-    iter = thermo_iter->findTag("vibrational_temperatures");
-    if (iter == thermo_iter->end()) return -1.0;
-
-    std::stringstream ss(iter->text());
-    double thetav; ss >> thetav;
-
-    return thetav;
-}
-
-//==============================================================================
-
-MillikanWhite::MillikanWhite(const class Thermodynamics& thermo)
-{
-    // Get the VT.xml file location.
-    std::string filename = databaseFileName("VT.xml", "transfer");
-    
-    // Open the VT file as an XML document
-    XmlDocument doc(filename);
-    
-    // Find the Millikan-White data
-    XmlElement::const_iterator iter = doc.root().findTag("Millikan-White");
-    if (iter == doc.root().end())
-        doc.root().parseError("Could not find Millikan-White element.");
-    const XmlElement& root = *iter;
-
-    // Loop over all molecules and load the Millikan-White data associated with
-    // them
-    int offset = (thermo.hasElectrons() ? 1 : 0);
-    for (int i = 0; i < thermo.nHeavy(); ++i) {
-        const Species& species = thermo.species(i+offset);
-        
-        // If this molecule can vibrate, add it to the list
-        if (species.type() == MOLECULE) {
-            // If vibrator is not in in VT.xml take the characteristic vibrational
-            // temperature from species.xml
-            if ((iter = root.findTagWithAttribute(
-                "vibrator", "species", species.name())) != root.end())
-                m_vibrators.push_back(
-                    MillikanWhiteVibrator(*iter, thermo));
-            else
-                m_vibrators.push_back(
-                    MillikanWhiteVibrator(species.name(), thermo));
-        }
-    }
-}
-
-//==============================================================================
 
     } // namespace Transfer
 } // namespace Mutation

--- a/src/transfer/MillikanWhite.h
+++ b/src/transfer/MillikanWhite.h
@@ -29,12 +29,14 @@
 #ifndef MILLIKAN_WHITE_H
 #define MILLIKAN_WHITE_H
 
-#include "Thermodynamics.h"
+#include <Eigen/Dense>
 
 #include <cmath>
 #include <memory>
 #include <string>
 #include <vector>
+
+namespace Mutation { namespace Thermodynamics { class Thermodynamics; } }
 
 namespace Mutation {
     namespace Transfer {
@@ -66,41 +68,48 @@ public:
     MillikanWhiteModelData(
         const class Thermodynamics::Thermodynamics&, size_t, double);
 
+    /// Copy constructor.
+    MillikanWhiteModelData(const MillikanWhiteModelData& data);
+
+    /// Copy assignment operator.
+    MillikanWhiteModelData& operator=(MillikanWhiteModelData data);
+
+    /// Move constructor.
+    MillikanWhiteModelData(MillikanWhiteModelData&& data) noexcept;
+
+    /// Move assignment operator.
+    MillikanWhiteModelData& operator=(MillikanWhiteModelData&& data) noexcept;
+
+    /// Destructor.
+    ~MillikanWhiteModelData();
+
     /// Index of species in mixture.
-    size_t speciesIndex() const { return m_index; }
+    size_t speciesIndex() const;
 
     /// Molecular weight of the vibrator in kg/mol
-    double molecularWeight() const { return m_mw; }
+    double molecularWeight() const;
 
     /// Returns the array of A model parameters.
-    Eigen::ArrayXd& a() { return m_a; }
+    Eigen::ArrayXd& a();
 
     /// Returns the array of A model parameters.
-    const Eigen::ArrayXd& a() const { return m_a; }
+    const Eigen::ArrayXd& a() const;
 
     /// Returns the array of B model parameters.
-    Eigen::ArrayXd& b() { return m_b; }
+    Eigen::ArrayXd& b();
 
     /// Returns the array of B model parameters.
-    const Eigen::ArrayXd& b() const { return m_b; }
+    const Eigen::ArrayXd& b() const;
 
     /// Returns the limiting cross section for Park's correction.
-    double limitingCrossSection() const { return m_omegav; }
+    double limitingCrossSection() const;
 
     /// Sets the limiting cross section in m^2.
-    MillikanWhiteModelData& setLimitingCrossSection(double omegav)
-    {
-        assert(omegav >= 0.0);
-        m_omegav = omegav;
-        return *this;
-    }
+    MillikanWhiteModelData& setLimitingCrossSection(double omegav);
 
 private:
-    size_t m_index = 0;
-    double m_mw = 0.0;
-    double m_omegav = 1.0E-20; // m^2
-    Eigen::ArrayXd m_a;
-    Eigen::ArrayXd m_b;
+    struct Impl;
+    std::unique_ptr<Impl> m_impl;
 };
 
 

--- a/src/transfer/MillikanWhite.h
+++ b/src/transfer/MillikanWhite.h
@@ -29,141 +29,129 @@
 #ifndef MILLIKAN_WHITE_H
 #define MILLIKAN_WHITE_H
 
+#include "Thermodynamics.h"
+
+#include <cmath>
+#include <memory>
 #include <string>
 #include <vector>
-#include <cmath>
-#include "Thermodynamics.h"
 
 namespace Mutation {
     namespace Transfer {
 
-/** 
- * Data storage for single Millikan-White collision pair.
- */
-class MillikanWhitePartner
-{
-public:
-
-    /**
-     * Construct using given values of a, b, and mu.
-     */
-    MillikanWhitePartner(double a, double b, double mu)
-        : m_a(a), m_b(b), m_mu(mu)
-    {}
-    
-    /**
-     * Construct using default values of a and b based on mu and theta.
-     */
-    MillikanWhitePartner(double mu, double theta)
-        : m_a(1.16E-3*std::sqrt(mu*1000.0)*std::pow(theta, 4.0/3.0)),
-          m_b(0.015*std::pow(mu*1000.0, 0.25)),
-          m_mu(mu)
-    { }
-    
-    double a()  const {return m_a; }
-    double b()  const {return m_b; }
-    double mu() const {return m_mu;}
-
-private:
-
-    double m_a;
-    double m_b;
-    double m_mu;
-};
-
 /**
- * Data storage for all collision partners of a vibrating species.
+ * Convenience class for building necessary data used in the Millikan-White
+ * vibration-translation energy relaxation model.
  */
-class MillikanWhiteVibrator
+class MillikanWhiteModelData
 {
 public:
+    /**
+     * Constructs default data for Millikan-White model from thermo model,
+     * species index, and characteristic vibrational temperature.  Default
+     * values for the A and B parameters in the Millikan-White model are taken
+     * from the original formulas in the paper:
+     * 
+     * \f{align*}{
+     * &A_{ij} = 1.16e-3 \mu_{ij}^{1/2} \theta_{i}^{4/3} \\
+     * &B_{ij} = 0.015 \mu_{ij}^{1/4}
+     * \f}
+     * 
+     * where \f$\mu_{ij}\f$ is the reduced mass of the vibrator and colliding
+     * partner in g/mol, and \f$\theta_{i}\f$ is the characteristic vibrational
+     * temperature of the vibrator.  The default value for Park's limiting 
+     * cross section is taken as 10^-16 cm^2, based on recommendation in
+     * @cite Gnoffo1989.
+     */
+    MillikanWhiteModelData(
+        const class Thermodynamics::Thermodynamics&, size_t, double);
 
-    /**
-     * Load available data from VT.xml and use defaults when data does not 
-     * exist.
-     */
-    MillikanWhiteVibrator(
-        const Mutation::Utilities::IO::XmlElement& node,
-        const Mutation::Thermodynamics::Thermodynamics& thermo);
-    
-    /**
-     * Use default data for all collision pairs with this vibrator.
-     */
-    MillikanWhiteVibrator(
-        const std::string& name,
-        const Mutation::Thermodynamics::Thermodynamics& thermo);
-    
-    /**
-     * Returns the (a,b,mu) data for the i'th heavy species colliding with this
-     * vibrator.
-     */
-    const MillikanWhitePartner& operator[](int i) const {
-        assert(i >= 0);
-        assert(i < m_partners.size());
-        return m_partners[i];
-    }
-    
-    /**
-     * Returns the limiting cross-section for vibrational excitation at 50,000 K
-     * for this vibrator.  Defaults to 3.0E-21 unless given differently in the 
-     * data file.
-     */
-    double omega() const {
-        return m_omegav;
-    }
-    
-    /**
-     * Returns the index of this vibrator in the mixture species list.
-     */
-    int index() const {
-        return m_index;
+    /// Index of species in mixture.
+    size_t speciesIndex() const { return m_index; }
+
+    /// Molecular weight of the vibrator in kg/mol
+    double molecularWeight() const { return m_mw; }
+
+    /// Returns the array of A model parameters.
+    Eigen::ArrayXd& a() { return m_a; }
+
+    /// Returns the array of A model parameters.
+    const Eigen::ArrayXd& a() const { return m_a; }
+
+    /// Returns the array of B model parameters.
+    Eigen::ArrayXd& b() { return m_b; }
+
+    /// Returns the array of B model parameters.
+    const Eigen::ArrayXd& b() const { return m_b; }
+
+    /// Returns the limiting cross section for Park's correction.
+    double limitingCrossSection() const { return m_omegav; }
+
+    /// Sets the limiting cross section in m^2.
+    MillikanWhiteModelData& setLimitingCrossSection(double omegav)
+    {
+        assert(omegav >= 0.0);
+        m_omegav = omegav;
+        return *this;
     }
 
 private:
-
-    /**
-     * Finds the characteristic vibrational temperature for this vibrator.
-     */
-    static double loadThetaV(const std::string& name);
-
-    std::vector<MillikanWhitePartner> m_partners;
-    double m_omegav;
-    double m_thetav;
-    int m_index;
+    size_t m_index = 0;
+    double m_mw = 0.0;
+    double m_omegav = 1.0E-20; // m^2
+    Eigen::ArrayXd m_a;
+    Eigen::ArrayXd m_b;
 };
 
 
 /**
- * Data storage for all of the information needed to evaluate the Millikan-White
- * vibration-translation energy transfer.
+ * @brief Millikan-White relaxation model with Park correction.
+ * 
+ * Implements the Millikan and White relaxation time model proposed in 
+ * @cite Millikan1963 with the high temperature correction of Park @cite Park1993.
+ * For an overview, see Eqs. (55-58) in @cite Gnoffo1989.
  */
-class MillikanWhite
+class MillikanWhiteModel
 {
 public:
-    /**
-     * Loads all of the data associated with the Millikan-White model.
-     */
-    MillikanWhite(const Mutation::Thermodynamics::Thermodynamics& thermo);
-    
-    /**
-     * Returns the number of vibrators being kept in this model.
-     */
-    int nVibrators() const {
-        return m_vibrators.size();
-    }
-    
-    /**
-     * Returns the i'th vibrator data.
-     */
-    const MillikanWhiteVibrator& operator[](int i) const {
-        assert(i >= 0);
-        assert(i < m_vibrators.size());
-        return m_vibrators[i];
-    }
+    /// Constructs a MillikanWhiteModel from data
+    MillikanWhiteModel(const MillikanWhiteModelData&);
+
+    /// Index of species in mixture.
+    size_t speciesIndex() const { return m_data.speciesIndex(); }
+
+    /// Molecular weight of the vibrator in kg/mol
+    double molecularWeight() const { return m_data.molecularWeight(); }
+
+    /// Relaxation time of the vibrator.
+    double relaxationTime(const Mutation::Thermodynamics::Thermodynamics&) const;
+
+    const MillikanWhiteModelData& data() const { return m_data; }
 
 private:
+    MillikanWhiteModelData m_data;
+};
 
-    std::vector<MillikanWhiteVibrator> m_vibrators;
+
+/// Builder for MillikanWhiteModel based on XML database.
+class MillikanWhiteModelDB
+{
+public:
+    /// Constructs the builder using default file path for "VT.xml".
+    MillikanWhiteModelDB(
+        const Mutation::Thermodynamics::Thermodynamics&);
+
+    /// Constructs the builder using given file path for database.
+    MillikanWhiteModelDB(
+        const Mutation::Thermodynamics::Thermodynamics&, std::string file_path);
+
+    /// Creates a MillikanWhiteModel given the species name and characteristic
+    /// vibrational temperature in K.
+    MillikanWhiteModel create(std::string species_name, double theta);
+
+private:
+    struct Data;
+    std::shared_ptr<Data> m_data;
 };
 
     } // namespace Kinetics

--- a/src/transfer/OmegaCE.cpp
+++ b/src/transfer/OmegaCE.cpp
@@ -53,9 +53,9 @@ public:
 
 	double source()
 	{
-		static const double cv = 1.5*RU/m_mixture.speciesMw(0);
-		m_mixture.netProductionRates(mp_wrk1);
-		return mp_wrk1[0]*cv*m_mixture.Te();
+		static const double cv = 1.5*RU/mixture().speciesMw(0);
+		mixture().netProductionRates(mp_wrk1);
+		return mp_wrk1[0]*cv*mixture().Te();
 	}
 
 private:

--- a/src/transfer/OmegaCElec.cpp
+++ b/src/transfer/OmegaCElec.cpp
@@ -58,15 +58,15 @@ public:
 
 	double source()
 	{
-		m_mixture.speciesHOverRT(NULL, NULL, NULL, NULL, mp_wrk1, NULL);
-		m_mixture.netProductionRates(mp_wrk2);
+		mixture().speciesHOverRT(NULL, NULL, NULL, NULL, mp_wrk1, NULL);
+		mixture().netProductionRates(mp_wrk2);
 
 		double sum = 0.0;
 
-		for(int i = 0 ; i < m_mixture.nSpecies(); ++i)
-			sum += mp_wrk1[i]*mp_wrk2[i]/m_mixture.speciesMw(i);
+		for(int i = 0 ; i < mixture().nSpecies(); ++i)
+			sum += mp_wrk1[i]*mp_wrk2[i]/mixture().speciesMw(i);
 
-		return (sum*m_mixture.T()*RU);
+		return (sum*mixture().T()*RU);
 	}
 
 private:

--- a/src/transfer/OmegaCV.cpp
+++ b/src/transfer/OmegaCV.cpp
@@ -59,7 +59,7 @@ public:
 	OmegaCV(Mutation::Mixture& mix)
 		: TransferModel(mix)
 	{
-		m_ns = m_mixture.nSpecies();
+		m_ns = mixture().nSpecies();
 		mp_wrk1 = new double [m_ns];
 		mp_wrk2 = new double [m_ns];
 	};
@@ -111,19 +111,19 @@ double const OmegaCV::compute_source_Candler()
 
 
 	 // Getting Vibrational Energy
-	 m_mixture.speciesHOverRT(NULL, NULL, NULL, mp_wrk1, NULL, NULL);
+	 mixture().speciesHOverRT(NULL, NULL, NULL, mp_wrk1, NULL, NULL);
 
 	 // Getting Production Rate
-	 m_mixture.netProductionRates(mp_wrk2);
+	 mixture().netProductionRates(mp_wrk2);
 
 	 // Inner Product
 	 double c1 = 1.0E0;
 	 double sum = 0.E0;
 
 	 for(int i = 0 ; i < m_ns; ++i)
-		 sum += mp_wrk1[i]*mp_wrk2[i]/m_mixture.speciesMw(i);
+		 sum += mp_wrk1[i]*mp_wrk2[i]/mixture().speciesMw(i);
 
-	 return(c1*sum*m_mixture.T()*RU);
+	 return(c1*sum*mixture().T()*RU);
  }
 
 // Register the transfer model

--- a/src/transfer/OmegaET.cpp
+++ b/src/transfer/OmegaET.cpp
@@ -67,13 +67,13 @@ public:
 	    if (!m_has_electrons)
 		    return 0.0;
 
-	    const double * p_X = m_mixture.X();
-        double nd = m_mixture.numberDensity();
-        double T = m_mixture.T();
-        double Te = m_mixture.Te();
+	    const double * p_X = mixture().X();
+        double nd = mixture().numberDensity();
+        double T = mixture().T();
+        double Te = mixture().Te();
 
-        const double ns = m_mixture.nSpecies();
-        Map<const ArrayXd> X(m_mixture.X(),ns);
+        const double ns = mixture().nSpecies();
+        Map<const ArrayXd> X(mixture().X(),ns);
 
         // CollisionDB data
         const ArrayXd& Q11ei = m_collisions.Q11ei();

--- a/src/transfer/OmegaI.cpp
+++ b/src/transfer/OmegaI.cpp
@@ -42,8 +42,8 @@ public:
     OmegaI(Mutation::Mixture& mix)
         : TransferModel(mix)
     {
-        m_ns = m_mixture.nSpecies();
-        m_nr = m_mixture.nReactions();
+        m_ns = mixture().nSpecies();
+        m_nr = mixture().nReactions();
         mp_hf = new double [m_ns];
         mp_h = new double [m_ns];
         mp_rate = new double [m_nr];
@@ -84,14 +84,14 @@ public:
     double source()
     {
         // Get Formation enthalpy
-        m_mixture.speciesHOverRT(mp_h, NULL, NULL, NULL, NULL, mp_hf);
+        mixture().speciesHOverRT(mp_h, NULL, NULL, NULL, NULL, mp_hf);
 
         // Get reaction enthalpies
         std::fill(mp_delta, mp_delta+m_nr, 0.0);
-        m_mixture.getReactionDelta(mp_hf,mp_delta);
+        mixture().getReactionDelta(mp_hf,mp_delta);
 
         // Get molar rates of progress
-        m_mixture.netRatesOfProgress(mp_rate);
+        mixture().netRatesOfProgress(mp_rate);
 
         double src = 0.0;
         int j;
@@ -100,7 +100,7 @@ public:
             src += mp_delta[j]*mp_rate[j];
         }
 
-        return (-src*RU*m_mixture.T());
+        return (-src*RU*mixture().T());
 
     }
 

--- a/src/transfer/TransferModel.h
+++ b/src/transfer/TransferModel.h
@@ -51,30 +51,19 @@ public:
     // Allows self-registration of TransferModel objects
     typedef Mutation::Mixture& ARGS;
 
-/**
- *@brief Returns name of this type.
- */
-
+    /// Name of this type.
     static std::string typeName() { return "TransferModel"; }
 
-    TransferModel(ARGS mix)
-        : m_mixture(mix)
-    { }
+    TransferModel(ARGS mix) : m_mixture(mix) { }
 
-/**
- *@brief Transfer Model destructor
- */
-    virtual ~TransferModel() { }
+    virtual ~TransferModel() = default;
 
-/**
- *@brief Purely virtual function to be called to
- * to solve the source term
- *
- * @return energy source term
- */
+    /// Value of source term in J/m^3-s.
     virtual double source() = 0;
 
 protected:
+    Mixture& mixture() { return m_mixture; }
+private:
     Mutation::Mixture& m_mixture;
 };
 

--- a/src/utilities/XMLite.h
+++ b/src/utilities/XMLite.h
@@ -180,7 +180,18 @@ public:
      * with the given name.
      */
     template <typename T>
-    T getAttribute(const std::string& name, T& value = T()) const;
+    T getAttribute(const std::string& name, T& value) const;
+
+    /**
+     * Returns the value of the corresponding attribute with the given name.  If
+     * the attribute is not given, then T() is returned.
+     */
+    template <typename T>
+    T getAttribute(const std::string& name) const
+    {
+        T value;
+        return getAttribute(name, value);
+    }
     
     /**
      * Returns an iterator pointing to the first child element in this

--- a/tests/c++/test_HarmonicOscillator.cpp
+++ b/tests/c++/test_HarmonicOscillator.cpp
@@ -1,0 +1,108 @@
+#include "HarmonicOscillator.h"
+#include "TemporaryFile.h"
+#include <catch.hpp>
+
+using namespace Mutation::Thermodynamics;
+using namespace Catch;
+
+/**
+ * Tests construction of harmonic oscillators.
+ */
+TEST_CASE("Harmonic oscillator construction", "[thermo]")
+{
+    SECTION("No characteristic temperatures")
+    {
+        HarmonicOscillator ho;
+        CHECK(ho.characteristicTemperatures().size() == 0);
+    }
+    
+    SECTION("One characteristic temperature")
+    {
+        std::vector<double> temps = { 1.0 };
+        HarmonicOscillator ho(temps);
+        CHECK(ho.characteristicTemperatures().size() == 1);
+        CHECK(ho.characteristicTemperatures()[0] == 1.0);
+    }
+
+    SECTION("One characteristic temperature")
+    {
+        std::vector<double> temps = { 1.0, 2.0, 3.0 };
+        HarmonicOscillator ho(temps);
+        CHECK(ho.characteristicTemperatures().size() == 3);
+        CHECK(ho.characteristicTemperatures()[0] == 1.0);
+        CHECK(ho.characteristicTemperatures()[1] == 2.0);
+        CHECK(ho.characteristicTemperatures()[2] == 3.0);
+    }
+}
+
+/**
+ * Tests harmonic oscillators energy calculation.
+ */
+TEST_CASE("Harmonic oscillator energy", "[thermo]")
+{
+    SECTION("No characteristic temperatures")
+    {
+        HarmonicOscillator ho;
+        CHECK(ho.energy(1.0) == 0.0);
+    }
+    
+    SECTION("One characteristic temperature")
+    {
+        std::vector<double> temps = { 1.0 };
+        HarmonicOscillator ho(temps);
+        CHECK(ho.energy(1.0) == Approx(0.581976706869326));
+    }
+
+    SECTION("One characteristic temperature")
+    {
+        std::vector<double> temps = { 1.0, 2.0, 3.0 };
+        HarmonicOscillator ho(temps);
+        CHECK(ho.energy(1.0) == Approx(1.052199081842426));
+    }
+}
+
+
+/**
+ * Tests loading of harmonic oscillators from database.
+ */
+TEST_CASE("Loading harmonic oscillator from database", "[thermo]")
+{
+    // Create a temporary database
+    Mutation::Utilities::IO::TemporaryFile file(".xml");
+    file << R"(
+    <specieslist>
+        <species name="CO2">
+            <thermodynamics type="RRHO">
+                <vibrational_temperatures units="K">
+                    932.109 932.109 1914.081 3373.804
+                </vibrational_temperatures>
+            </thermodynamics>
+        </species>
+        <species name="N2">
+            <thermodynamics type="RRHO">
+                <vibrational_temperatures units="K">
+                    3408.464
+                </vibrational_temperatures>
+            </thermodynamics>
+        </species>
+    </specieslist>)";
+    file.close();
+
+    HarmonicOscillatorDB db(file.filename());
+
+    auto ho = db.create("CO2");
+    CHECK(ho.characteristicTemperatures().size() == 4);
+    CHECK(ho.characteristicTemperatures()[0] == 932.109);
+    CHECK(ho.characteristicTemperatures()[1] == 932.109);
+    CHECK(ho.characteristicTemperatures()[2] == 1914.081);
+    CHECK(ho.characteristicTemperatures()[3] == 3373.804);
+
+    ho = db.create("N2");
+    CHECK(ho.characteristicTemperatures().size() == 1);
+    CHECK(ho.characteristicTemperatures()[0] == 3408.464);
+
+    ho = db.create("test");
+    CHECK(ho.characteristicTemperatures().size() == 0);
+}
+
+

--- a/tests/c++/test_MillikanWhite.cpp
+++ b/tests/c++/test_MillikanWhite.cpp
@@ -1,0 +1,125 @@
+#include "MillikanWhite.h"
+#include "Mixture.h"
+#include "TemporaryFile.h"
+#include <catch.hpp>
+
+using namespace Mutation;
+using namespace Mutation::Transfer;
+using namespace Catch;
+
+void checkDefaultModelData(bool with_electrons)
+{
+    const std::string species_list = (with_electrons ? "e- N2 O2 N" : "N2 O2 N");
+    const size_t offset = (with_electrons ? 1 : 0);
+        
+    MixtureOptions opts;
+    opts.setSpeciesDescriptor(species_list);
+    Mixture mix(opts);
+
+    const double thetav = 3408.464;
+    MillikanWhiteModelData data(mix, offset, thetav);
+    
+    CHECK(data.speciesIndex() == offset);
+    CHECK(data.molecularWeight() == mix.speciesMw(offset));
+    CHECK(data.limitingCrossSection() == 1.0e-20);
+    REQUIRE(data.a().size() == 3);
+    REQUIRE(data.b().size() == 3);
+
+    const double mw = mix.speciesMw(offset);
+
+    for (size_t i = 0; i < 3; ++i)
+    {
+        const double mwi = mix.speciesMw(i+offset);
+        const double mu = 1000.0*mw*mwi/(mw+mwi); // g/mol
+        
+        CHECK(data.a()[i] == 1.16e-3*std::sqrt(mu)*std::pow(thetav, 4.0/3.0));
+        CHECK(data.b()[i] == 0.015*std::pow(mu, 0.25));
+    }
+}
+
+/**
+ * Tests that Millikan-White model data defaults to correct values.
+ */
+TEST_CASE("MillikanWhiteModelData provides default model values", "[transfer]")
+{
+    checkDefaultModelData(false);
+    checkDefaultModelData(true);
+}
+
+void checkDefaultRelaxationRate(bool with_electrons)
+{
+    INFO(std::string("with_electrons = ") + (with_electrons ? "true" : "false"));
+    const std::string species_list = (with_electrons ? "e- N2" : "N2");
+    const size_t offset = (with_electrons ? 1 : 0);
+    
+    MixtureOptions opts;
+    opts.setSpeciesDescriptor(species_list);
+    opts.setStateModel("ChemNonEq1T");
+    Mixture mix(opts);
+
+    const double thetav = 3408.464;
+    MillikanWhiteModel model({mix, offset, thetav});
+
+    const int SET_Y_AND_PT = 2;
+    
+    std::vector<double> y;
+    if (with_electrons)
+        y.push_back(0.0);
+    y.push_back(1.0);
+
+    const double pT[] = { ONEATM, 300.0 };
+    mix.setState(y.data(), pT, SET_Y_AND_PT);
+    
+    const double mu = 1000.0*0.5*mix.speciesMw(offset);
+    const double A = 1.16e-3*std::sqrt(mu)*std::pow(thetav, 4.0/3.0);
+    const double B = 0.015*std::pow(mu, 0.25);
+    const double tau_mw = std::exp(A*(std::pow(300.0, -1.0/3.0) - B) - 18.42);
+    
+    const double ni = mix.numberDensity();
+    const double ci = std::sqrt(8*RU*300.0/(PI*mix.speciesMw(offset)));
+    const double tau_park = 1.0/(ni * ci * 1.0e-20);
+    
+    CHECK(model.relaxationTime(mix) == tau_mw + tau_park);
+}
+
+TEST_CASE("MillikanWhiteModel provides correct default relaxation time", "[transfer]")
+{
+    checkDefaultRelaxationRate(false);
+    checkDefaultRelaxationRate(true);
+}
+
+TEST_CASE("Can load MillikanWhiteModel from database", "[transfer]")
+{
+    // Create a temporary database
+    Mutation::Utilities::IO::TemporaryFile file(".xml");
+    file << R"(
+    <VT>
+        <Millikan-White>
+            <vibrator species="N2" omegav="3.0E-21">
+                <partner species="N" a="180.0" b ="0.0262" />
+                <partner species="N2" a="221" b="0.0290" />
+            </vibrator>
+        </Millikan-White>
+    </VT>)";
+    file.close();
+
+    MixtureOptions opts;
+    opts.setSpeciesDescriptor("N2 N");
+    Mixture mix(opts);
+
+    MillikanWhiteModelDB db(mix, file.filename());
+
+    auto model = db.create("N2", 3408.464);
+
+    CHECK(model.speciesIndex() == 0);
+    CHECK(model.molecularWeight() == mix.speciesMw(0));
+    CHECK(model.data().a().size() == 2);
+    CHECK(model.data().b().size() == 2);
+
+    CHECK(model.data().a()[0] == 221.0);
+    CHECK(model.data().b()[0] == 0.0290);
+    
+    CHECK(model.data().a()[1] == 180.0);
+    CHECK(model.data().b()[1] == 0.0262);
+}
+

--- a/tests/c++/test_bug_139.cpp
+++ b/tests/c++/test_bug_139.cpp
@@ -113,9 +113,8 @@ void testMixture(
 }
 
 
-// Check the three cases associated with issue 139
 TEST_CASE(
-    "Bug #139 fix: vibronic energies unchanged after setState()",
+    "Bug #139 fix: vibronic energies unchanged after setState",
     "[bugs][thermodynamics]"
 )
 {


### PR DESCRIPTION
This is a redesign of the OmegaVT class and associated Millikan-White model classes in response to #171.  In addition to now using the correct implementation for the Millikan-White model as discussed in #171, the redesign provides additional improvements, including:

1. Separation of relaxation time model and energy model into separate classes (`MillikanWhiteModel` and `HarmonicOscillator`)
2. Separation of model behavior and creation for both new model types using builder pattern to create model instances from XML databases
3. Separation of default model data for the Millikan-White model from data non-default data provided in a database via the `MillikanWhiteModelData` class
4. `OmegaVT` now manages generic "vibrator" objects which could implement different relaxation or energy models in the future and the energy transfer source term is now computed in a clear way following the generic Landau-Teller form, regardless of the relaxation time model used
5. The redesign also allows an easy extension of the `OmegaVT` class for situations where multiple vibrational temperatures are used, for example by providing a list of vibrator species names to be managed by the specific source term.

In addition to the design improvements, there is a significant increase in documentation, including clearly citing the sources for default data and model equations in the literature.  Finally, several test cases have also been added to test each new class as separately as possible.  Note, there is still some ugly coupling with Thermodynamics that is basically imposed by needing state information to compute the relaxation rate.  This could be improved in the future but is out of the scope of this redesign.

Finally, there is a small change to the name of the test case "Bug #139 fix: vibronic energies unchanged after setState()" because this test was not actually being picked up by the ctest suite as due to a problem in the test name parsing.