### PR TITLE
Fix install path for fortran module and export name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ jobs:
     build_linux:
         strategy:
           matrix:
-            os: [ubuntu-16.04, ubuntu-18.04, ubuntu-latest]
+            os: [ubuntu-18.04, ubuntu-latest]
             build_type: [Debug, Release]
             compiler: [gcc g++, clang clang++]
         runs-on: ${{ matrix.os }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ cmake_policy(SET CMP0048 NEW)
 set(CMAKE_CXX_STANDARD 14)
 
 project(mutation++
-    VERSION 1.1.0
+    VERSION 1.1.1
     LANGUAGES CXX
 )
 

--- a/interface/fortran/CMakeLists.txt
+++ b/interface/fortran/CMakeLists.txt
@@ -22,8 +22,6 @@
 cmake_minimum_required(VERSION 2.6)
 cmake_policy(SET CMP0022 NEW)
 
-include(GNUInstallDirs)
-
 add_library(mutation++_fortran
     SHARED 
         cwrapper.cpp 
@@ -34,6 +32,7 @@ add_library(mutation++::fortran_interface ALIAS mutation++_fortran)
 set_target_properties(mutation++_fortran 
     PROPERTIES
         Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        EXPORT_NAME fortran_interface
 )
 
 target_link_libraries(mutation++_fortran
@@ -41,14 +40,14 @@ target_link_libraries(mutation++_fortran
         mutation++
 )
 install(TARGETS mutation++_fortran EXPORT mutation++Targets
-    LIBRARY  DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE  DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    LIBRARY  DESTINATION ${INSTALL_LIB_DIR}
+    ARCHIVE  DESTINATION ${INSTALL_LIB_DIR}
+    INCLUDES DESTINATION ${INSTALL_INCLUDE_DIR}
 )
 
 install(
     FILES 
     ${CMAKE_CURRENT_BINARY_DIR}/mutationpp.mod 
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    DESTINATION ${INSTALL_INCLUDE_DIR}
 )
 


### PR DESCRIPTION
The example CMakeLists for the fortran interface was not working outside
of the Mutation++ build tree because the only target exported was named
`mutation++_fortran` and not `mutation++::fortran_interface` as shown in
the [CMakeLists.txt.shared](https://github.com/mutationpp/Mutationpp/blob/master/examples/fortran/CMakeLists.txt.shared) in interface/fortran. Now it's fixed

Also the Fortran module file was installed in the wrong include dir