### PR TITLE
Add ability to set the GSI mechanism in MixtureOptions.

### DIFF
--- a/src/general/MixtureOptions.h
+++ b/src/general/MixtureOptions.h
@@ -218,6 +218,13 @@ public:
     const std::string& getGSIMechanism() const {
         return m_gsi_mechanism;
     }
+    
+    /**
+     * Sets the Gas-Surface Interaction mechanism to use.
+     */
+    void setGSIMechanism(const std::string& gsi_mechanism) {
+        m_gsi_mechanism = gsi_mechanism;
+    }
 
 //    /**
 //     * Sets the default mixture composition in elemental mole fractions.


### PR DESCRIPTION
Add the ability to set the GSI mechanism in the MixtureOptions
class.

See #180. Closes #180.