### PR TITLE
Fix minor bug in SurfaceBalanceSolverMassEnergy

### DIFF
--- a/src/gsi/SurfaceBalanceSolverMassEnergy.cpp
+++ b/src/gsi/SurfaceBalanceSolverMassEnergy.cpp
@@ -243,7 +243,7 @@ public:
 
     void updateFunction(Eigen::VectorXd& v_X)
     {
-        applyTolerance(mv_X);
+        applyTolerance(v_X);
         // Comment: (+) If flux enters the volume.
         // Assuming the normal vector of the surface to be pointing from the
         // solid to the gas phase.


### PR DESCRIPTION
Fix a minor bug in the `updateFunction` routine in the
`SurfaceBalanceSolverMassEnergy` class. The `applyTolerance`
function was being incorrectly applied to `mv_X` rather than `v_X`.

See #185. Closes #185.