### PR TITLE
fixed small typo in mppequil

### DIFF
--- a/src/apps/mppequil.cpp
+++ b/src/apps/mppequil.cpp
@@ -280,7 +280,7 @@ void printHelpMessage(const char* const name)
 
     cout << endl;
     cout << "Example:" << endl;
-    cout << tab << name << " -T 300:100:15000 -P 101325 -m 1-3,8 air11" << endl;
+    cout << tab << name << " -T 300:100:15000 -P 101325 -m 1-3,8 air_11" << endl;
     cout << endl;
 
     exit(0);


### PR DESCRIPTION
A small typo was left in the "mppequil -h", probably from a (recent?) renaming of air_11 mixture