### PR TITLE
Fix install dir detection for the Fortran wrapper

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,76 +2,75 @@ name: Build
 on: [push, pull_request]
 
 jobs:
-    build_linux:
-        strategy:
-          matrix:
-            os: [ubuntu-18.04, ubuntu-latest]
-            build_type: [Debug, Release]
-            compiler: [gcc g++, clang clang++]
-        runs-on: ${{ matrix.os }}
-        steps:
-          - uses: actions/checkout@v1
-          - name: Make build dir
-            run: mkdir build 
-          - name: Make install dir
-            run: mkdir install
-          - name: configure
-            run: > 
-                export CC=$(echo "${{ matrix.compiler }}"| cut -d' ' -f1)  && 
-                export CXX=$(echo "${{ matrix.compiler }}" | cut -d' ' -f2) && 
-                cd build && cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_TESTING:BOOL=TRUE -DCMAKE_INSTALL_PREFIX=../install ..
-          - name: build
-            run: cd build && make -j $(nproc) && make install
-          - name: test
-            run: >
-                export MPP_DIRECTORY=$(pwd) &&
-                export MPP_DATA_DIRECTORY=$MPP_DIRECTORY/data &&
-                export LD_LIBRARY_PATH=$MPP_DIRECTORY/install/lib:$LD_LIBRARY_PATH &&
-                cd build && ctest -j $(nproc)
+  build_linux:
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, ubuntu-latest]
+        build_type: [Debug, Release]
+        compiler: [gcc g++, clang clang++]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v1
+      - name: Make build dir
+        run: mkdir build
+      - name: Make install dir
+        run: mkdir install
+      - name: configure
+        run: >
+          export CC=$(echo "${{ matrix.compiler }}"| cut -d' ' -f1)  && 
+          export CXX=$(echo "${{ matrix.compiler }}" | cut -d' ' -f2) && 
+          cd build && cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_TESTING:BOOL=TRUE -DCMAKE_INSTALL_PREFIX=../install -DBUILD_FORTRAN_WRAPPER:BOOL=TRUE ..
+      - name: build
+        run: cd build && make -j $(nproc) && make install
+      - name: test
+        run: >
+          export MPP_DIRECTORY=$(pwd) &&
+          export MPP_DATA_DIRECTORY=$MPP_DIRECTORY/data &&
+          export LD_LIBRARY_PATH=$MPP_DIRECTORY/install/lib:$LD_LIBRARY_PATH &&
+          cd build && ctest -j $(nproc)
 
-    build_mac:
-        runs-on: macos-latest
-        steps:
-          - uses: actions/checkout@v1
-          - name: Make build dir
-            run: mkdir build 
-          - name: Make install dir
-            run: mkdir install
-          - name: configure
-            run: cd build && cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_TESTING:BOOL=TRUE -DCMAKE_INSTALL_PREFIX=../install ..
-          - name: build
-            run: cd build && make -j $(nproc) && make install
-          - name: test
-            run: >
-                export MPP_DIRECTORY=$(pwd) &&
-                export MPP_DATA_DIRECTORY=$MPP_DIRECTORY/data &&
-                export LD_LIBRARY_PATH=$MPP_DIRECTORY/install/lib:$LD_LIBRARY_PATH &&
-                cd build && ctest -j $(nproc)
+  build_mac:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Make build dir
+        run: mkdir build
+      - name: Make install dir
+        run: mkdir install
+      - name: configure
+        run: cd build && cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_TESTING:BOOL=TRUE -DCMAKE_INSTALL_PREFIX=../install  ..
+      - name: build
+        run: cd build && make -j $(nproc) && make install
+      - name: test
+        run: >
+          export MPP_DIRECTORY=$(pwd) &&
+          export MPP_DATA_DIRECTORY=$MPP_DIRECTORY/data &&
+          export LD_LIBRARY_PATH=$MPP_DIRECTORY/install/lib:$LD_LIBRARY_PATH &&
+          cd build && ctest -j $(nproc)
 
-    coverage:
-        runs-on: ubuntu-latest
-        steps:
-          - uses: actions/checkout@v1
-          - name: Install Lcov, Gcov
-            run: sudo apt install lcov
-          - name: Make build dir
-            run: mkdir build 
-          - name: Make install dir
-            run: mkdir install
-          - name: configure
-            run: cd build && cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_TESTING:BOOL=TRUE -DENABLE_COVERAGE:BOOL=TRUE -DCMAKE_INSTALL_PREFIX=../install ..
-          - name: build
-            run: cd build && make -j $(nproc) && make install
-          - name: test
-            run: >
-                export MPP_DIRECTORY=$(pwd) &&
-                export MPP_DATA_DIRECTORY=$MPP_DIRECTORY/data &&
-                export LD_LIBRARY_PATH=$MPP_DIRECTORY/install/lib:$LD_LIBRARY_PATH &&
-                cd build && ctest -j $(nproc)
-          - name: coverage
-            run: cd build && make coverage
-          - name: Codecov
-            run: > 
-                cd build && 
-                bash <(curl -s https://codecov.io/bash) -f mutation++.info || echo "Codecov did not collect coverage reports"
-
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install Lcov, Gcov
+        run: sudo apt install lcov
+      - name: Make build dir
+        run: mkdir build
+      - name: Make install dir
+        run: mkdir install
+      - name: configure
+        run: cd build && cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_TESTING:BOOL=TRUE -DENABLE_COVERAGE:BOOL=TRUE -DCMAKE_INSTALL_PREFIX=../install ..
+      - name: build
+        run: cd build && make -j $(nproc) && make install
+      - name: test
+        run: >
+          export MPP_DIRECTORY=$(pwd) &&
+          export MPP_DATA_DIRECTORY=$MPP_DIRECTORY/data &&
+          export LD_LIBRARY_PATH=$MPP_DIRECTORY/install/lib:$LD_LIBRARY_PATH &&
+          cd build && ctest -j $(nproc)
+      - name: coverage
+        run: cd build && make coverage
+      - name: Codecov
+        run: >
+          cd build && 
+          bash <(curl -s https://codecov.io/bash) -f mutation++.info || echo "Codecov did not collect coverage reports"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,6 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules/")
 enable_language(CXX)
 if (BUILD_FORTRAN_WRAPPER)
     enable_language(Fortran)
-    add_subdirectory(interface/fortran)
 endif()
 
 #######################################################################
@@ -63,20 +62,11 @@ endif()
 ###############################################################################
 
 # Profile
-set (CMAKE_CXX_FLAGS_PROFILE "-g3 -Wall -O3 -DNDEBUG" CACHE STRING
-    "Flags used by the C++ compiler during Profile builds."
-    FORCE )
-set (CMAKE_C_FLAGS_PROFILE "-g3 -Wall -pedantic -O3 -DNDEBUG" CACHE STRING
-    "Flags used by the C compiler during Profile builds."
-    FORCE )
-set (CMAKE_EXE_LINKER_FLAGS_PROFILE
-    "" CACHE STRING
-    "Flags used for linking binaries during Profile builds."
-    FORCE )
-set (CMAKE_SHARED_LINKER_FLAGS_PROFILE
-    "" CACHE STRING
-    "Flags used by the shared libraries linker during Profile builds."
-    FORCE )
+set (CMAKE_CXX_FLAGS_PROFILE "-g3 -Wall -O3 -DNDEBUG")
+set (CMAKE_C_FLAGS_PROFILE "-g3 -Wall -pedantic -O3 -DNDEBUG")
+set (CMAKE_EXE_LINKER_FLAGS_PROFILE)
+set (CMAKE_SHARED_LINKER_FLAGS_PROFILE)
+
 mark_as_advanced(
     CMAKE_CXX_FLAGS_PROFILE
     CMAKE_C_FLAGS_PROFILE
@@ -161,6 +151,7 @@ if (BUILD_FORTRAN_WRAPPER)
         set (CMAKE_Fortran_FLAGS_RELEASE "-O3")
         set (CMAKE_Fortran_FLAGS_DEBUG   "-g -traceback -fpe0 -check all")
     endif()
+    add_subdirectory(interface/fortran)
 endif()
 
 ################################################################################

--- a/cmake/modules/ParseAndAddCatchTests.cmake
+++ b/cmake/modules/ParseAndAddCatchTests.cmake
@@ -46,7 +46,7 @@
 #                                                                                                  #
 #==================================================================================================#
 
-cmake_minimum_required(VERSION 2.8.8)
+cmake_minimum_required(VERSION 2.8.12)
 
 option(PARSE_CATCH_TESTS_VERBOSE "Print Catch to CTest parser debug messages" OFF)
 option(PARSE_CATCH_TESTS_NO_HIDDEN_TESTS "Exclude tests with [!hide], [.] or [.foo] tags" OFF)

--- a/tests/c++/CMakeLists.txt
+++ b/tests/c++/CMakeLists.txt
@@ -19,8 +19,6 @@
 # <http://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 2.6)
-
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 configure_file(Configuration.h.in Configuration.h)
 


### PR DESCRIPTION
Also enable build of the Fortran wrapper in CI

Inspired by #192, but without caching variables. It also adds the Fortran wrapper build in the Github action

Close #191 