### PR TITLE
Cache compiler flag variables in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,14 +142,26 @@ if (BUILD_FORTRAN_WRAPPER)
 
     if (Fortran_COMPILER_NAME STREQUAL "gfortran")
         # gfortran
-        set (CMAKE_Fortran_FLAGS         "-fdefault-real-8")
-        set (CMAKE_Fortran_FLAGS_RELEASE "-O3")
-        set (CMAKE_Fortran_FLAGS_DEBUG   "-g")
+        set (CMAKE_Fortran_FLAGS "-fdefault-real-8" CACHE STRING
+             "Flags used by the Fortran compiler during all builds."
+             FORCE )
+        set (CMAKE_Fortran_FLAGS_RELEASE "-O3" CACHE STRING
+             "Flags used by the Fortran compiler during Release builds."
+             FORCE )
+        set (CMAKE_Fortran_FLAGS_DEBUG "-g" CACHE STRING
+             "Flags used by the Fortran compiler during Debug builds."
+             FORCE )
     elseif (Fortran_COMPILER_NAME STREQUAL "ifort")
         # ifort (untested)
-        set (CMAKE_Fortran_FLAGS         "-r8")
-        set (CMAKE_Fortran_FLAGS_RELEASE "-O3")
-        set (CMAKE_Fortran_FLAGS_DEBUG   "-g -traceback -fpe0 -check all")
+        set (CMAKE_Fortran_FLAGS "-r8" CACHE STRING
+             "Flags used by the Fortran compiler during all builds."
+             FORCE )
+        set (CMAKE_Fortran_FLAGS_RELEASE "-O3" CACHE STRING
+             "Flags used by the Fortran compiler during Release builds."
+             FORCE )
+        set (CMAKE_Fortran_FLAGS_DEBUG "-g -traceback -fpe0 -check all" CACHE STRING
+             "Flags used by the Fortran compiler during Debug builds."
+             FORCE )
     endif()
     add_subdirectory(interface/fortran)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,11 +62,20 @@ endif()
 ###############################################################################
 
 # Profile
-set (CMAKE_CXX_FLAGS_PROFILE "-g3 -Wall -O3 -DNDEBUG")
-set (CMAKE_C_FLAGS_PROFILE "-g3 -Wall -pedantic -O3 -DNDEBUG")
-set (CMAKE_EXE_LINKER_FLAGS_PROFILE)
-set (CMAKE_SHARED_LINKER_FLAGS_PROFILE)
-
+set (CMAKE_CXX_FLAGS_PROFILE "-g3 -Wall -O3 -DNDEBUG" CACHE STRING
+    "Flags used by the C++ compiler during Profile builds."
+    FORCE )
+set (CMAKE_C_FLAGS_PROFILE "-g3 -Wall -pedantic -O3 -DNDEBUG" CACHE STRING
+    "Flags used by the C compiler during Profile builds."
+    FORCE )
+set (CMAKE_EXE_LINKER_FLAGS_PROFILE
+    "" CACHE STRING
+    "Flags used for linking binaries during Profile builds."
+    FORCE )
+set (CMAKE_SHARED_LINKER_FLAGS_PROFILE
+    "" CACHE STRING
+    "Flags used by the shared libraries linker during Profile builds."
+    FORCE )
 mark_as_advanced(
     CMAKE_CXX_FLAGS_PROFILE
     CMAKE_C_FLAGS_PROFILE


### PR DESCRIPTION
Closes #190. Caches the Fortran CMake compiler flag variables.

Reverts part of ab639ae. Restores the `CACHE` attribute to the C++ compiler flags.

See discussion on #192 for further details.