### PR TITLE
Closes #171. Fix Park's correction to the relaxation time.

### DIFF
--- a/src/transfer/MillikanWhite.h
+++ b/src/transfer/MillikanWhite.h
@@ -61,9 +61,10 @@ public:
      * 
      * where \f$\mu_{ij}\f$ is the reduced mass of the vibrator and colliding
      * partner in g/mol, and \f$\theta_{i}\f$ is the characteristic vibrational
-     * temperature of the vibrator.  The default value for Park's limiting 
+     * temperature of the vibrator.  The default value for Park's reference 
      * cross section is taken as 10^-16 cm^2, based on recommendation in
-     * @cite Gnoffo1989.
+     * @cite Gnoffo1989. The high-temperature limiting cross section is based
+     * on @cite Park1993.
      */
     MillikanWhiteModelData(
         const class Thermodynamics::Thermodynamics&, size_t, double);
@@ -101,11 +102,14 @@ public:
     /// Returns the array of B model parameters.
     const Eigen::ArrayXd& b() const;
 
-    /// Returns the limiting cross section for Park's correction.
-    double limitingCrossSection() const;
+    /// Sets the reference cross section in m^2.
+    MillikanWhiteModelData& setReferenceCrossSection(double omegav);
 
-    /// Sets the limiting cross section in m^2.
-    MillikanWhiteModelData& setLimitingCrossSection(double omegav);
+    /// Returns the reference cross section for Park's correction in m^2.
+    double referenceCrossSection() const;
+
+    /// Returns the limiting cross section for Park's correction in m^2.
+    double limitingCrossSection(const double& T) const;
 
 private:
     struct Impl;

--- a/tests/c++/test_MillikanWhite.cpp
+++ b/tests/c++/test_MillikanWhite.cpp
@@ -21,7 +21,8 @@ void checkDefaultModelData(bool with_electrons)
     
     CHECK(data.speciesIndex() == offset);
     CHECK(data.molecularWeight() == mix.speciesMw(offset));
-    CHECK(data.limitingCrossSection() == 1.0e-20);
+    CHECK(data.referenceCrossSection() == 1.0e-20);
+    CHECK(data.limitingCrossSection(mix.T()) == 1.0e-20 * (2.5e9/(mix.T()*mix.T())));
     REQUIRE(data.a().size() == 3);
     REQUIRE(data.b().size() == 3);
 
@@ -77,7 +78,8 @@ void checkDefaultRelaxationRate(bool with_electrons)
     
     const double ni = mix.numberDensity();
     const double ci = std::sqrt(8*RU*300.0/(PI*mix.speciesMw(offset)));
-    const double tau_park = 1.0/(ni * ci * 1.0e-20);
+    const double sigma = 1e-20 * (2.5E9/(300.0*300.0));
+    const double tau_park = 1.0/(ni * ci * sigma);
     
     CHECK(model.relaxationTime(mix) == tau_mw + tau_park);
 }


### PR DESCRIPTION
Fix Park's correction to the relaxation time.
The temperature term was inadvertently removed in bc9ce81.

Also updates the unit test for Millikan-White.

See #171. Closes #171.