### PR TITLE
Fix averageHeavyCollisionFreq in Python interface.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,7 @@ foreach (dir LIB BIN INCLUDE CMAKE)
     mark_as_advanced(${inst_dir})
 
     # Make the paths absolute (the ${${var}} notation is evaluating the
-    # evaluated variable. :: I.e. ${inst_dir} first evaluates, for example, 
+    # evaluated variable. :: I.e. ${inst_dir} first evaluates, for example,
     # to INSTALL_LIB_DIR. Then ${${inst_dir}} evaluates to ${INSTALL_LIB_DIR}
     # that respectively evaluates to the directory path containing libraries
     if(NOT IS_ABSOLUTE "${${inst_dir}}")
@@ -174,14 +174,6 @@ if (BUILD_FORTRAN_WRAPPER)
     endif()
     add_subdirectory(interface/fortran)
 endif()
-
-################################################################################
-
-# Python wrapper options
-###############################################################################
-
-option (BUILD_PYTHON_WRAPPER
-    "Generate a Python package for using mutation++" OFF)
 
 ###############################################################################
 # Doxygen documentation generation

--- a/interface/python/src/pyMixture.cpp
+++ b/interface/python/src/pyMixture.cpp
@@ -700,7 +700,7 @@ void py_export_Mixture(py::module &m) {
            "Electron-heavy collision frequency in 1/s.")
 
       .def("averageHeavyCollisionFreq",
-           &Mutation::Mixture::electronHeavyCollisionFreq,
+           &Mutation::Mixture::averageHeavyCollisionFreq,
            "Average collision frequency of heavy particles in mixture in 1/s.")
 
       .def("electricConductivity", &Mutation::Mixture::electricConductivity,

--- a/src/apps/mppequil.cpp
+++ b/src/apps/mppequil.cpp
@@ -61,7 +61,7 @@ struct OutputQuantity {
 };
 
 // List of all mixture output quantities
-#define NMIXTURE 45
+#define NMIXTURE 46
 OutputQuantity mixture_quantities[NMIXTURE] = {
     OutputQuantity("Th", "K", "heavy particle temperature"),
     OutputQuantity("P", "Pa", "pressure"),
@@ -110,8 +110,8 @@ OutputQuantity mixture_quantities[NMIXTURE] = {
     OutputQuantity("a_f", "m/s", "frozen speed of sound"),
     OutputQuantity("a_eq", "m/s", "equilibrium speed of sound"),
     OutputQuantity("Eam", "V/K", "ambipolar electric field (SM Ramshaw)"),
-    OutputQuantity("drho/dP", "kg/J", "equilibrium density derivative w.r.t pressure")
-//    OutputQuantity("l", "m", "mean free path"),
+    OutputQuantity("drho/dP", "kg/J", "equilibrium density derivative w.r.t pressure"),
+    OutputQuantity("l", "m", "mean free path")
 //    OutputQuantity("le", "m", "mean free path of electrons"),
 //    OutputQuantity("Vh", "m/s", "average heavy particle thermal speed"),
 //    OutputQuantity("Ve", "m/s", "electron thermal speed"),
@@ -834,8 +834,8 @@ int main(int argc, char** argv)
                     mix.stefanMaxwell(temp, temp2, value);
                 } else if (name == "drho/dP")
                     value = mix.dRhodP();
-//                else if (name == "l")
-//                    value = mix.meanFreePath();
+                else if (name == "l")
+                    value = mix.meanFreePath();
 //                else if (name == "le")
 //                    value = mix.electronMeanFreePath();
 //                else if (name == "Vh")

--- a/src/transport/Transport.cpp
+++ b/src/transport/Transport.cpp
@@ -171,7 +171,7 @@ void Transport::heavyThermalDiffusionRatios(double* const p_k)
 
 void Transport::frozenThermalConductivityVector(double* const p_lambda)
 {
-	const int neq = m_thermo.nEnergyEqns();
+    const int neq = m_thermo.nEnergyEqns();
     double lambda_th, lambda_te, lambda_rot, lambda_vib, lambda_elec;
 
     if(neq > 1) {
@@ -207,7 +207,7 @@ double Transport::internalThermalConductivity(double T)
 
 double Transport::rotationalThermalConductivity()
 {
-	m_thermo.speciesCpOverR(
+    m_thermo.speciesCpOverR(
         m_thermo.T(), m_thermo.Te(), m_thermo.Tr(), m_thermo.Tv(), m_thermo.Tel(),
         NULL, NULL, mp_wrk1, NULL, NULL);
 
@@ -218,7 +218,7 @@ double Transport::rotationalThermalConductivity()
 
 double Transport::vibrationalThermalConductivity()
 {
-	m_thermo.speciesCpOverR(
+    m_thermo.speciesCpOverR(
         m_thermo.T(), m_thermo.Te(), m_thermo.Tr(), m_thermo.Tv(), m_thermo.Tel(),
         NULL, NULL, NULL, mp_wrk1, NULL);
 
@@ -229,7 +229,7 @@ double Transport::vibrationalThermalConductivity()
 
 double Transport::electronicThermalConductivity()
 {
-	m_thermo.speciesCpOverR(
+    m_thermo.speciesCpOverR(
         m_thermo.T(), m_thermo.Te(), m_thermo.Tr(), m_thermo.Tv(), m_thermo.Tel(),
         NULL, NULL, NULL, NULL, mp_wrk1);
 
@@ -240,7 +240,7 @@ double Transport::electronicThermalConductivity()
 
 double Transport::reactiveThermalConductivity()
 {
-	// Compute dX_i/dT
+    // Compute dX_i/dT
     m_thermo.dXidT(mp_wrk1);
 
     // Compute the thermal diffusion ratios
@@ -346,10 +346,10 @@ double Transport::butlerBrokawThermalConductivity()
 
 double Transport::soretThermalConductivity()
 {
-	// @todo This is super inefficient, should fix
-	Eigen::VectorXd work(m_thermo.nGas());
+    // @todo This is super inefficient, should fix
+    Eigen::VectorXd work(m_thermo.nGas());
 
-	// Compute dX_i/dT
+    // Compute dX_i/dT
     m_thermo.dXidT(mp_wrk1);
 
     // Compute the thermal diffusion ratios
@@ -376,64 +376,64 @@ double Transport::soretThermalConductivity()
 
 void Transport::equilDiffFluxFacs(double* const p_F)
 {
-	// Get some state data
-	const int ns = m_thermo.nGas();
-	const int ne = m_thermo.nElements();
-	const double* const p_Y = m_thermo.Y();
-	const double* const p_X = m_thermo.X();
-	const double rho = m_thermo.density();
-	const double p   = m_thermo.P();
+    // Get some state data
+    const int ns = m_thermo.nGas();
+    const int ne = m_thermo.nElements();
+    const double* const p_Y = m_thermo.Y();
+    const double* const p_X = m_thermo.X();
+    const double rho = m_thermo.density();
+    const double p   = m_thermo.P();
 
-	const MatrixXd& Dij = diffusionMatrix();
-	const Eigen::MatrixXd& nu  = m_thermo.elementMatrix();
+    const MatrixXd& Dij = diffusionMatrix();
+    const Eigen::MatrixXd& nu  = m_thermo.elementMatrix();
 
-	for (int i = 0; i < ns; ++i) {
-		mp_wrk2[i] = 0.0;
-		for (int j = 0; j < ns; ++j)
-			mp_wrk2[i] += Dij(i,j)*mp_wrk1[j];
-		mp_wrk2[i] *= -rho*p_Y[i]/m_thermo.speciesMw(i);
-	}
+    for (int i = 0; i < ns; ++i) {
+        mp_wrk2[i] = 0.0;
+        for (int j = 0; j < ns; ++j)
+            mp_wrk2[i] += Dij(i,j)*mp_wrk1[j];
+        mp_wrk2[i] *= -rho*p_Y[i]/m_thermo.speciesMw(i);
+    }
 
-	for (int k = 0; k < ne; ++k) {
-		p_F[k] = 0.0;
-		double mwk = m_thermo.atomicMass(k);
-		for (int i = 0; i < ns; ++i)
-			p_F[k] += nu(i,k)*mwk*mp_wrk2[i];
-	}
+    for (int k = 0; k < ne; ++k) {
+        p_F[k] = 0.0;
+        double mwk = m_thermo.atomicMass(k);
+        for (int i = 0; i < ns; ++i)
+            p_F[k] += nu(i,k)*mwk*mp_wrk2[i];
+    }
 
-	m_thermo.speciesHOverRT(mp_wrk1);
-	p_F[ne] = 0.0;
-	for (int i = 0; i < ns; ++i)
-		p_F[ne] += mp_wrk1[i]*mp_wrk2[i];
-	p_F[ne] *= RU * m_thermo.T();
+    m_thermo.speciesHOverRT(mp_wrk1);
+    p_F[ne] = 0.0;
+    for (int i = 0; i < ns; ++i)
+        p_F[ne] += mp_wrk1[i]*mp_wrk2[i];
+    p_F[ne] *= RU * m_thermo.T();
 }
 
 //==============================================================================
 
 void Transport::equilDiffFluxFacsP(double* const p_F)
 {
-	const int ns = m_thermo.nGas();
-	const double p = m_thermo.P();
-	const double* const p_Y = m_thermo.Y();
-	const double* const p_X = m_thermo.X();
+    const int ns = m_thermo.nGas();
+    const double p = m_thermo.P();
+    const double* const p_Y = m_thermo.Y();
+    const double* const p_X = m_thermo.X();
 
     // Compute the dXj/dP term
     m_thermo.dXidP(mp_wrk1);
 
-	// Add the (x_j - y_j)/p term
-	for (int i = 0; i < ns; ++i)
-		mp_wrk1[i] += (p_X[i] - p_Y[i])/p;
+    // Add the (x_j - y_j)/p term
+    for (int i = 0; i < ns; ++i)
+        mp_wrk1[i] += (p_X[i] - p_Y[i])/p;
 
     // Compute the element averaged diffusion coefficients
-	equilDiffFluxFacs(p_F);
+    equilDiffFluxFacs(p_F);
 }
 
 //==============================================================================
 
 void Transport::equilDiffFluxFacsT(double* const p_F)
 {
-	const int ns = m_thermo.nGas();
-	const double T  = m_thermo.T();
+    const int ns = m_thermo.nGas();
+    const double T  = m_thermo.T();
 
     Eigen::Map<Eigen::ArrayXd> work1(mp_wrk1, ns);
     Eigen::Map<Eigen::ArrayXd> work2(mp_wrk2, ns);
@@ -441,45 +441,45 @@ void Transport::equilDiffFluxFacsT(double* const p_F)
     // Compute the dXj/dT term
     m_thermo.dXidT(work1.data());
 
-	// Add thermal diffusion ratio term
-	heavyThermalDiffusionRatios(work2.data());
+    // Add thermal diffusion ratio term
+    heavyThermalDiffusionRatios(work2.data());
     work1 += work2 / T;
 
     // @todo Add electron thermal diffusion ratios
 
     // Compute the element averaged diffusion coefficients
-	equilDiffFluxFacs(p_F);
+    equilDiffFluxFacs(p_F);
 }
 
 //==============================================================================
 
 void Transport::equilDiffFluxFacsZ(double* const p_F)
 {
-	const int ns = m_thermo.nGas();
-	const int ne = m_thermo.nElements();
-	const double* const p_X = m_thermo.X();
+    const int ns = m_thermo.nGas();
+    const int ne = m_thermo.nElements();
+    const double* const p_X = m_thermo.X();
     const double T   = m_thermo.T();
     const double p   = m_thermo.P();
 
-	// Loop over each element
-	for (int l = 0; l < ne; ++l) {
-	   // Compute the dXj/dZl term using a finite difference
-	   m_thermo.elementFractions(p_X, mp_wrk1);
-	   double h = std::max(mp_wrk1[l]*1.0e-6, 1.0e-10);
-	   mp_wrk1[l] += h;
-	   m_thermo.equilibriumComposition(T, p, mp_wrk1, mp_wrk2);
+    // Loop over each element
+    for (int l = 0; l < ne; ++l) {
+       // Compute the dXj/dZl term using a finite difference
+       m_thermo.elementFractions(p_X, mp_wrk1);
+       double h = std::max(mp_wrk1[l]*1.0e-6, 1.0e-10);
+       mp_wrk1[l] += h;
+       m_thermo.equilibriumComposition(T, p, mp_wrk1, mp_wrk2);
 
-	   for (int i = 0; i < ns; ++i)
-		   mp_wrk1[i] = (mp_wrk2[i]-p_X[i])/h;
+       for (int i = 0; i < ns; ++i)
+           mp_wrk1[i] = (mp_wrk2[i]-p_X[i])/h;
 
-	   // Compute the element averaged diffusion coefficients
-	   equilDiffFluxFacs(p_F + l*(ne+1));
-	}
+       // Compute the element averaged diffusion coefficients
+       equilDiffFluxFacs(p_F + l*(ne+1));
+    }
 
-	// Be sure to set the state back in the equilibrium solver in case other
-	// calculations rely on the correct element potential values
-	m_thermo.elementFractions(p_X, mp_wrk1);
-	m_thermo.equilibriumComposition(T, p, mp_wrk1, mp_wrk2);
+    // Be sure to set the state back in the equilibrium solver in case other
+    // calculations rely on the correct element potential values
+    m_thermo.elementFractions(p_X, mp_wrk1);
+    m_thermo.equilibriumComposition(T, p, mp_wrk1, mp_wrk2);
 }
 
 //==============================================================================
@@ -750,30 +750,27 @@ void Transport::smCorrectionsHeavy(int order, Eigen::ArrayXd& phi)
 double Transport::meanFreePath()
 {
     // Thermo properties
-         const int ns = m_thermo.nGas();
-         const double Th = m_thermo.T();
-           const double Te = m_thermo.Te();
-                 const double nd = m_thermo.numberDensity();
-                    const double* const X = m_thermo.X();
-                    const double me = m_thermo.speciesMw(0)/NA;
-                   const Eigen::ArrayXd& Q11 = m_collisions.Q11ij();
-        const double Q11ee = m_collisions.Q11ee();
-        const Eigen::ArrayXd& Q11ei = m_collisions.Q11ei();
+    const int ns = m_thermo.nGas();
+    const double Th = m_thermo.T();
+    const double Te = m_thermo.Te();
+    const double nd = m_thermo.numberDensity();
+    const double* const X = m_thermo.X();
+    const double me = m_thermo.speciesMw(0)/NA;
+    const Eigen::ArrayXd& Q11 = m_collisions.Q11ij();
+    const double Q11ee = m_collisions.Q11ee();
+    const Eigen::ArrayXd& Q11ei = m_collisions.Q11ei();
 
+    double sum = 0.0;
+    sum +=X[0]*X[0]*Q11ee;
+    for (int i = 1; i < ns; ++i)
+        sum +=X[i]*X[0]*Q11ei(i);
 
-                                         double sum = 0.0;
-            sum +=X[0]*X[0]*Q11ee;
-                for (int i = 1; i < ns; ++i)
-            {
-            sum +=X[i]*X[0]*Q11ei(i);
-            ;}
+    for (int i = 1; i < ns; ++i)
+        for (int j = 1; j < ns; ++j)
+            sum += X[i]*X[j]*Q11(i,j);
 
-                                           for (int i = 1; i < ns; ++i)
-                                                for (int j = 1; j < ns; ++j)
-                                                               sum += X[i]*X[j]*Q11(i,j);
-
-                                                                   return 1.0/(nd*sum);
-                                                                 }
+    return 1.0/(nd*sum);
+}
 //==============================================================================
 
 
@@ -791,12 +788,9 @@ double Transport::electronMeanFreePath()
     const double Q11ee = m_collisions.Q11ee();
     const Eigen::ArrayXd& Q11ei = m_collisions.Q11ei();
     double sum = 0.0;
-            sum +=X[0]*X[0]*Q11ee;
-                        for (int i = 1; i < ns; ++i)
-                        {
-                        sum +=X[i]*X[0]*Q11ei(i);
-                        ;}
-
+    sum +=X[0]*X[0]*Q11ee;
+    for (int i = 1; i < ns; ++i)
+        sum +=X[i]*X[0]*Q11ei(i);
 
     return 1.0/(nd*sum);
 }
@@ -804,10 +798,10 @@ double Transport::electronMeanFreePath()
 //==============================================================================
 double Transport::speciesThermalSpeed(const int& i) const
 {
-	if (i < m_thermo.hasElectrons()){
-	    const double T = m_thermo.Te();
+    if (i < m_thermo.hasElectrons()){
+        const double T = m_thermo.Te();
         return sqrt(8.0*RU*T/(PI*m_thermo.speciesMw(i)));
-	}
+    }
 
     const double T = m_thermo.T();
     return sqrt(8.0*RU*T/(PI*m_thermo.speciesMw(i)));
@@ -864,18 +858,16 @@ double Transport::coulombMeanCollisionTime()
     const Eigen::ArrayXd& Q11 = m_collisions.Q11ij();
     const double Q11ee = m_collisions.Q11ee();
     const Eigen::ArrayXd& Q11ei = m_collisions.Q11ei();
-                        sum +=X[0]*X[0]*Q11ee;
-                        for (int i = 1; i < ns; ++i)
-                        {
-                        sum +=X[i]*X[0]*Q11ei(i);
-                        ;}
+    sum +=X[0]*X[0]*Q11ee;
+    for (int i = 1; i < ns; ++i)
+        sum +=X[i]*X[0]*Q11ei(i);
 
-                                           for (int i = 1; i < ns; ++i)
-                                                for (int j = 1; j < ns; ++j)
-                                                               sum += X[i]*X[j]*Q11(i,j);
+    for (int i = 1; i < ns; ++i)
+        for (int j = 1; j < ns; ++j)
+            sum += X[i]*X[j]*Q11(i,j);
 
-     return (3.0/16.0)*1.0/(nd*sum)/averageHeavyThermalSpeed();//electronThermalSpeed();
-     }
+    return (3.0/16.0)*1.0/(nd*sum)/averageHeavyThermalSpeed();//electronThermalSpeed();
+}
 
 //==============================================================================
 double Transport::hallParameter()

--- a/src/transport/Transport.cpp
+++ b/src/transport/Transport.cpp
@@ -787,20 +787,14 @@ double Transport::electronMeanFreePath()
     if (!m_thermo.hasElectrons())
         return 0.0;
 
-    const int ns = m_thermo.nGas();
-    const double Th = m_thermo.T();
-    const double Te = m_thermo.Te();
-    const double nd = m_thermo.numberDensity();
     const double* const X = m_thermo.X();
-
-    const double Q11ee = m_collisions.Q11ee();
     const Eigen::ArrayXd& Q11ei = m_collisions.Q11ei();
-    double sum = 0.0;
-    sum +=X[0]*X[0]*Q11ee;
-    for (int i = 1; i < ns; ++i)
-        sum +=X[i]*X[0]*Q11ei(i);
 
-    return 1.0/(nd*sum);
+    double sum = X[0]*X[0]*m_collisions.Q11ee();
+    for (int i = 1; i < m_thermo.nGas(); ++i)
+        sum += 2.0*X[i]*X[0]*Q11ei(i);
+
+    return 1.0/(m_thermo.numberDensity()*sum);
 }
 
 //==============================================================================

--- a/src/transport/Transport.cpp
+++ b/src/transport/Transport.cpp
@@ -850,25 +850,7 @@ double Transport::coulombMeanCollisionTime()
 {
     if (!m_thermo.hasElectrons())
         return 0.0;
-
-    const int ns = m_thermo.nGas();
-    const double Th = m_thermo.T();
-    const double Te = m_thermo.Te();
-    const double nd = m_thermo.numberDensity();
-    const double* const X = m_thermo.X();
-    double sum = 0.0;
-    const Eigen::ArrayXd& Q11 = m_collisions.Q11ij();
-    const double Q11ee = m_collisions.Q11ee();
-    const Eigen::ArrayXd& Q11ei = m_collisions.Q11ei();
-    sum +=X[0]*X[0]*Q11ee;
-    for (int i = 1; i < ns; ++i)
-        sum +=X[i]*X[0]*Q11ei(i);
-
-    for (int i = 1; i < ns; ++i)
-        for (int j = 1; j < ns; ++j)
-            sum += X[i]*X[j]*Q11(i,j);
-
-    return (3.0/16.0)*1.0/(nd*sum)/averageHeavyThermalSpeed();//electronThermalSpeed();
+    return (3.0/16.0)*meanFreePath()/averageHeavyThermalSpeed();//electronThermalSpeed();
 }
 
 //==============================================================================

--- a/tests/python/test_mutation.py
+++ b/tests/python/test_mutation.py
@@ -156,8 +156,8 @@ def test_mixtureSMass():
     assert mixture.mixtureSMass() == pytest.approx(8218.83, abs=1e-2)
 
 
-# def test_meanFreePath():
-#     Todo: write proper test
+def test_meanFreePath():
+    assert mixture.meanFreePath() == pytest.approx(1.1470317911509538e-05)
 
 def test_nAtoms():
     assert mixture.nAtoms() == 4

--- a/tests/python/test_mutation.py
+++ b/tests/python/test_mutation.py
@@ -19,7 +19,7 @@ mixtureNonEq.setState(rhoi, T, 1)
 # Todo: write proper test
 
 def test_averageHeavyCollisionFreq():
-    assert mixture.averageHeavyCollisionFreq() == pytest.approx(0.0)
+    assert mixture.averageHeavyCollisionFreq() == pytest.approx(4.0906953e7)
 
 
 #


### PR DESCRIPTION
Fix an issue with the `averageHeavyCollisionFreq` function in the Python interface.
It was incorrectly returning the `electronHeavyCollisionFreq`, likely due to a copy-paste error.

See #221. Closes #221.