### PR TITLE
Closes #237. Remove ubuntu-18.04 from GitHub actions.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ jobs:
   build_linux:
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-latest]
+        os: [ubuntu-latest]
         build_type: [Debug, Release]
         compiler: [gcc g++, clang clang++]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Remove `ubuntu-18.04` from the build actions for GitHub. The 18.04 image was deprecated in April 2023.

See #237. Closes #237.