### PR TITLE
Closes #240. Clean up docs

### DIFF
--- a/docs/bibliography.md
+++ b/docs/bibliography.md
@@ -27,8 +27,8 @@ E. A. Mason, R. J. Munn, and Francis J. Smith.
 _Physics of Fluids_, 10(8):1827, 1967.
 
 <a id="McBride1996"></a>
-McBride and Sanford.
-[Computer Program for Calculation of Complex Chemical Equilibrium Compositions and Applications: II. Users Manual and Program Description](https://www.grc.nasa.gov/www/CEAWeb/RP-1311-P2.pdf).
+McBride, B. J. and Sanford, G.
+[Computer Program for Calculation of Complex Chemical Equilibrium Compositions and Applications: II. Users Manual and Program Description](https://ntrs.nasa.gov/citations/19960044559).
 _NASA RP 1311_, 1996.
 
 <a id="Murphy1995"></a>

--- a/docs/bibliography.md
+++ b/docs/bibliography.md
@@ -2,10 +2,41 @@
 
 # Bibliography
 
+<a id="Bruno2010"></a>
+D. Bruno, C. Catalfamo, M. Capitelli, G. Colonna, O. De Pascale, P. Diomede, C. Gorse, A. Laricchiuta, S. Longo, D. Giordano, and F. Pirani
+[Transport properties of high-temperature Jupiter atmosphere components](https://doi.org/10.1063/1.3495980), _Physics of Plasmas_ 17, 112315 (2010).
+
+<a id="Cambi1991"></a>
+Cambi, D. Cappelletti, G. Liuti, and F. Pirani,
+[Generalized correlations in terms of polarizability for van der Waals interaction potential parameter calculations](https://doi.org/10.1063/1.461035),
+_Journal of Chemical Physics_ 95, 1852 (1991).
+
+<a id="Devoto1973"></a>
+R. S. Devoto.
+[Transport coefficients of ionized argon](https://doi.org/10.1063/1.1694396),
+_Physics of Fluids_, 16(5):616, (1973).
+
+<a id="Laricchiuta2007"></a>
+A. Laricchiuta, G. Colonna, D. Bruno, R. Celiberto, C. Gorse, F. Pirani, and M. Capitelli.
+[Classical transport collision integrals for a Lennard-Jones like phenomenological model potential](https://doi.org/10.1016/j.cplett.2007.07.097),
+_Chemical Physics Letters_ 445, 133–139, (2007).
+
+<a id="Mason1967"></a>
+E. A. Mason, R. J. Munn, and Francis J. Smith.
+[Transport Coefficients of Ionized Gases](https://doi.org/10.1063/1.1762365),
+_Physics of Fluids_, 10(8):1827, 1967.
+
 <a id="McBride1996"></a>
-McBride and Sanford. 
-[Computer Program for Calculation of Complex Chemical Equilibrium Compositions and Applicaitons: II. Users Manual and Program Description](https://www.grc.nasa.gov/www/CEAWeb/RP-1311-P2.pdf). 
+McBride and Sanford.
+[Computer Program for Calculation of Complex Chemical Equilibrium Compositions and Applications: II. Users Manual and Program Description](https://www.grc.nasa.gov/www/CEAWeb/RP-1311-P2.pdf).
 _NASA RP 1311_, 1996.
 
+<a id="Murphy1995"></a>
+A. B. Murphy.
+[Transport coefficients of air, argon-air, nitrogen-air, and oxygen-air plasmas](https://doi.org/10.1007/BF01459700),
+_Plasma Chemistry and Plasma Processing_, 15(2):279–307, 1995. 86,
 
-
+<a id="Pirani2004"></a>
+F. Pirani, M. Alberti, A. Castro, M. M. Teixidor, and D. Cappelletti,
+[Atom–bond pairwise additive representation for intermolecular potential energy surfaces](https://doi.org/10.1016/j.cplett.2004.06.100),
+_Chemical Physics Letters_ 394, 37–44 (2004).

--- a/docs/input-files.md
+++ b/docs/input-files.md
@@ -1029,12 +1029,14 @@ three dimensional fluxes reduce to the normal fluxes at the interface while the 
 source terms, such as chemical reactions, go to zero; only the surface sources remain.
 Generally, the set of balance equations can be written as:
 
-(**F**_g - **F**_b) . **n** = &#937;_s,
+$$
+(\vec{F}_g - \vec{F}_b) \cdot \hat{n} = \Omega_s,
+$$
 
-where **F** are the fluxes from the gas (**g**) and the bulk (**b**) phases, while
-&#937; are the source terms associated to the surface (s) processes.
+where $\vec{F}$ are the fluxes from the gas ($g$) and the bulk ($b$) phases, while
+$\Omega$ are the source terms associated to the surface ($s$) processes.
 Only the normal to surface flux component should be considered, denoted by
-the inner product of the flux with the surface unit vector, (**n**).
+the inner product of the flux with the surface unit vector, ($\hat{n}$).
 The specific form of the balance equations for mass and energy will be seen in the following
 sections.
 
@@ -1043,7 +1045,7 @@ sections.
 
 Below the input file when a single catalytic reaction is presented.
 Only the recombination of atomic into molecular oxygen is considered
-modeled with the gamma &#947; model, with reaction probability equal to 1.
+modeled with the $\gamma$ (gamma) model, with reaction probability equal to 1.
 
 ```xml
 <gsi gsi_mechanism = "phenomenological_mass">
@@ -1061,39 +1063,46 @@ modeled with the gamma &#947; model, with reaction probability equal to 1.
 </gsi>
 ```
 
-The &#947; model, introduced by Goulard in the late 50s, is arguably the most popular
+The $\gamma$ model, introduced by Goulard in the late 1950s, is arguably the most popular
 way to treat catalysis in the aero-thermodynamics community. It describes catalytic
 reactions as macroscopic, non-elementary processes of the form:
 
-A + A -> A2
+$$
+\mathrm{A} + \mathrm{A} \to \mathrm{A_2}
+$$
 
 In order to determine the chemical production term for this kind of catalytic reactions a
-probability for recombination &#947; is defined for each recombining species A as:
+probability for recombination $\gamma$ is defined for each recombining species A as:
 
+$$
+\gamma = F_{rec} / F_{imp},
+$$
 
-&#947; = F_rec / F_imp,
-
-
-where F_imp is the flux of species A impinging the surface and
-F_rec is the flux of species recombining at the surface. This probability is
-the input parameter for the model. A fully catalytic wall has &#947; equal to 1, which
+where $F_{imp}$ is the flux of species A impinging the surface and
+$F_{rec}$ is the flux of species recombining at the surface. This probability is
+the input parameter for the model. A fully catalytic wall has $\gamma$ equal to 1, which
 means that all the particles of species A impinging the surface recombine at the wall.
-&#947; equal to 0 means that no reaction takes place and corresponds
+$\gamma$ equal to 0 means that no reaction takes place and corresponds
 to a non catalytic, or chemically inert wall. Anything between these two extreme cases is a
 partially catalytic wall, which is the case for most of the surfaces. When the probability
-&#947; is defined, the surface chemical source term is determined as:
+$\gamma$ is defined, the surface chemical source term is determined as:
 
-&#937;_A = &#947; m F_imp
+$$
+\begin{align}
+\Omega_A &= \gamma m_A F_{imp} \\
+\Omega_{A2} &= - \gamma m_A F_{imp}
+\end{align}
+$$
 
-&#937;_A2 = - &#947; m F_imp
-
-with m being the mass of species A.
+with $m_A$ being the mass of species A.
 
 The only parameter that still needs to be defined is the impinging flux on the surface.
 When the distribution function of species at the wall is well approximated by a Maxwellian
-and there is no temperature slip, the impinging flux, F_imp, is equal to
+and there is no temperature slip, the impinging flux, $F_{imp}$, is equal to
 
-F_imp = n_A (k_B T / 2 &#960; m_A)^(1/2)
+$$
+F_{imp} = n_A \sqrt{\frac{k_B T}{2 \pi m_A}}
+$$
 
 according to the kinetic theory of gases.
 
@@ -1102,28 +1111,35 @@ such as the one presented in above.
 Soon, though, it was observed that heteronuclear reactions were also probable
 to occur at the wall, which can take the form of
 
-A + B -> AB,
+$$
+\mathrm{A} + \mathrm{B} \to \mathrm{AB},
+$$
 
 with the chemical rate for the produced molecule AB equal to:
 
-&#937;_AB  = - &#947;_AB m_A F_imp_A - &#947;_BA m_B F_imp_B.
+$$
+\Omega_{AB}  = - \gamma_{AB} m_A F_{imp,A} - \gamma_{BA} m_B F_{imp,B}.
+$$
 
 One atom of A recombines with one atom of B on the surface to produce a molecule AB.
 In other words the number of atoms of A that recombine into AB should be equal to the number of B
 atoms that recombine into AB. This restriction should be explicitly imposed in order to conserve mass:
 
-&#947;_AB F_imp_A = &#947;_BA F_imp_B.
+$$
+\gamma_{AB} F_{imp,A} = \gamma_{BA} F_{imp,B}.
+$$
 
 As a result, in a reaction of this type two gamma recombination coefficients should be defined not
 necessarily equal for the two processes, the one activated when the catalytic reaction is limited by the
 flux of A atoms and the opposite. In practice the two recombination number fluxes,
-&#947;_AB F_imp_A and &#947;_BA F_imp_B, are compared and the limiting one
+$\gamma_{AB} F_{imp,A}$ and $\gamma_{BA} F_{imp,B}$, are compared and the limiting one
 determines which of the two gammas is chosen.
 
 These gamma coefficients cannot take arbitrary values, they should be limited between 0 and 1,
 just like in the homonuclear case. When extra catalytic reactions are added,
-such as A + A -> A2 and B + B -> B2 the gammas should be further constrained
-as 0 &#60; &#947;_A + &#947;_AB &#60; 1 and 0 &#60; &#947;_B + &#947;_BA &#60; 1
+such as $\mathrm{A} + \mathrm{A} \to \mathrm{A_2}$ and $\mathrm{B} + \mathrm{B} \to \mathrm{B_2}$,
+the gammas should be further constrained
+as $0 \lt \gamma_A + \gamma_{AB} \lt 1$ and $0 \lt \gamma_B + \gamma_{BA} \lt 1$
 in order for mass to be conserved. This approach is consistent with similar approaches
 considering the catalytic recombination occurring in Martian atmospheres, where O can recombine
 into both O2 and CO2 due to catalytic reactions.
@@ -1240,29 +1256,35 @@ An example of ablation model can be seen below.
 The first ablation reaction presented above is the oxidation
 of the solid carbon by atomic oxygen. The reaction reads as:
 
-C_b + O -> CO
+$$
+\mathrm{C}_b + \mathrm{O} \to \mathrm{CO}
+$$
 
 and is exothermic, releasing 3.74 eV per molecule produced. Its reaction
 rate coefficient is given by defining a recombination probability
-&#947;_CO. This probability is an Arrhenius type function of temperature
+$\gamma_{CO}$. This probability is an Arrhenius type function of temperature
 and is given by the formula:
 
-&#947;_CO = 0.63 exp(-1160 / T).
+$$
+\gamma_{CO} = 0.63 \exp \left(\frac{-1160~\mathrm{K}}{T} \right).
+$$
 
 Carbon oxidation with molecular oxygen is also possible
-C_b + O2 -> CO + O, but it is often considered as a less significant
-process.
+($\mathrm{C}_b + \mathrm{O_2} \to \mathrm{CO} + \mathrm{O}$),
+but it is often considered as a less significant process.
 
 #### Carbon Nitridation Model
 <a id="cnitr"></a>
 
 The second shown in the example is carbon nitridation,
 
-C_b + N -> CN,
+$$
+\mathrm{C}_b + \mathrm{N} \to \mathrm{CN}
+$$
 
 an exothermic reaction with 0.35 eV of energy released per reacting atom.
 The reaction rate is given using a constant recombination probability
-&#947;_CN like in the catalytic case.
+$\gamma_{CN}$ like in the catalytic case.
 
 #### Carbon Sublimation Model
 <a id="csubl"></a>
@@ -1271,16 +1293,22 @@ At high temperatures carbon removal from the surface is dominated by phase
 change processes like sublimation. The production of C3 is considered here.
 It should be noted that this type of reactions are invertible, with formula:
 
-3C_b -> C3.
+$$
+3\mathrm{C}_b \to \mathrm{C_3}
+$$
 
 The chemical production rate of this reaction is equal to:
 
-&#937;_C3 = &#946; (&#961;_eq_C3 - &#961;_C3) (k_B T / 2 &#960; m)^(1/2).
+$$
+\Omega_{C_3} = \beta (\rho_{eq,C_3} - \rho_{C_3}) \sqrt{\frac{k_B T}{2 \pi m}}.
+$$
 
 The equilibrium partial density of the C3 species is obtained from the
 saturated vapor pressure of carbon, which is equal to
 
-p_sat_C3 = c \exp (-Ta / T)
+$$
+p_{sat,C_3} = c \exp \left( \frac{-Ta}{T} \right)
+$$
 
 with &#946_C3 being the evaporation coefficient, c the pre-exponential coefficient,
 and Ta the activation temperature.
@@ -1314,7 +1342,9 @@ If all of the phenomena above are modeled with accuracy, the re-entry heat load 
 and the size of the thermal protection system can be determined.
 The mass balance on a catalytic surface reads:
 
-**j**_i . **n** = &#937;_cat_i,
+$$
+\vec{j}_i \cdot \hat{n} = \Omega_{cat,i},
+$$
 
 where one mass balance equation should be solved for each distinct species in the flow.
 The equation above states, that the catalytic activity of every species is equal to the diffusion
@@ -1345,14 +1375,16 @@ processes also in the bulk, such as in the case of pyrolysis.
 
 Taking these ideas in mind, the surface mass balance accounting only for surface reactions becomes:
 
-&#961;_i (**u**_g - **u**_r) + **j**_i - **F**_b_i ] . **n** = &#937;_i,
+$$
+[\rho_i (\vec{u}_g - \vec{u}_r) + \vec{j}_i - \vec{F}_{b,i} ] \cdot \hat{n} = \Omega_i,
+$$
 
-with &#937;_i = &#937;_cat_i + &#937;_abl_i and
-term **F**_b_i is the flux of species i entering the interface due
+with $\Omega_i = \Omega_{cat,i} + \Omega_{abl,i}$ and
+term $\vec{F}_{b,i}$ is the flux of species $i$ entering the interface due
 to solid process, like pyrolysis and solid-solid chemical reactions.
 Just like before, one mass balance equation should be solved for each distinct species in the flow.
 It is most of the time reasonable to consider that recession velocity is
-orders of magnitude lower than the gas velocity **u**_r.
+orders of magnitude lower than the gas velocity $\vec{u}_r$.
 
 ### Surface Energy Balance
 <a id="seb"></a>
@@ -1360,26 +1392,29 @@ orders of magnitude lower than the gas velocity **u**_r.
 In order to determine the surface temperature a surface energy balance should be solved along
 with the mass balances. It takes the form:
 
-( &#961; ( **u**_g - **u**_r ) H + **q**g
-    - **F**_b_e ) . **n** = &#937;_e;
+$$
+[ \rho ( \vec{u}_g - \vec{u}_r ) H + \vec{q}_g - \vec{F}_{b,e} ] \cdot \hat{n} = \Omega_e
+$$
 
-where **q**_g is the heat flux to the gas phase equal to:
+where $\vec{q}_g$ is the heat flux to the gas phase equal to:
 
-**q**_g = -&#955; &#8711; T + &#931; **j**_i h_i.
+$$
+\vec{q}_g = -\lambda \nabla T + \sum_i \vec{j}_i h_i.
+$$
 
 The radiative heat flux can be also included and will be discussed along with the surface
 radiation.
 
-Term **F**_b_e describes the energy exchanged between the interface
+Term $\vec{F}_{b,e}$ describes the energy exchanged between the interface
 and the bulk of the solid and is composed of three contributions: the first one is the
-thermal conduction exiting the surface **q**_cond, the second one is the
+thermal conduction exiting the surface $\vec{q}_{cond}$, the second one is the
 enthalpy entering the interface due to the movement of the surface with the recession velocity,
-**u**_r &#961; h_s and the third one appears only in cases of
+$\vec{u}_r \rho h_s$ and the third one appears only in cases of
 porous material, describing the enthalpy of the solid pyrolysis gases convected in the interface,
-denoted as **u**_p &#961;_p; h_p. The subscript p symbolizes
-the pyrolysis gas properties, with the &#961;_p h_p being actually the
-sum &#931; = &#961;_i h_i for the pyrolysis gas densities. The surface
-enthalpy h_s is an input to the code, as an attribute to the surface_properties element.
+denoted as $\vec{u}_p \rho_p h_p$. The subscript $p$ symbolizes
+the pyrolysis gas properties, with the $\rho_p h_p$ being actually the
+sum $\sum_i = \rho_i h_i$ for the pyrolysis gas densities. The surface
+enthalpy $h_s$ is an input to the code, as an attribute to the surface_properties element.
 
 An example input file for solving both mass and energy balance can be seen below.
 ```xml
@@ -1426,15 +1461,17 @@ An example input file for solving both mass and energy balance can be seen below
 
 The only source term taken into account for the surface energy balance in the
 example above is radiation. It is considered by adding a new element with tag
-<surface_radiation/>. The surface is assumed to be in thermodynamic equilibrium
+`<surface_radiation/>`. The surface is assumed to be in thermodynamic equilibrium
 at a temperature T emitting energy following the Stefan-Boltzmann law,
 
-&#937;_e = &#937;_rad = &#949; ( &#963; T^4 - **q**_rad_g)
+$$
+\Omega_e = \Omega_{rad} = \epsilon ( \sigma T^4 - \vec{q}_{rad,g})
+$$
 
-with &#963; being the Stefan-Boltzmann constant and &#949; the emissivity
-of the surface. T_env is the surrounding environment temperature which can
+with $\sigma$ being the Stefan-Boltzmann constant and $\epsilon$ the emissivity
+of the surface. $T_{env}$ is the surrounding environment temperature which can
 be used to simulate the far field radiative heat flux based on the formula
- &#963; T_env^4, which replaces the term **q**_rad_g.
+ $\sigma T_{env}^4$, which replaces the term $\vec{q}_{rad,g}$.
 This is a relatively bad approximation and, therefore, it is better to be omitted.
 
 In order to obtain the value for the conductive heat flux on the solid,
@@ -1446,21 +1483,25 @@ the simulations. Such an approximation was adopted here for the modeling of the
 conductive heat flux inside the material, the steady-state ablation approach for a
 semi-infinite surface. By writing the steady-state energy equation for the solid phase
 and integrating over the semi-infinite material, where on one side is the solid
-properties at exactly the interface (subscript s), while on the other, at infinity,
-is the virgin material (subscript v), the steady state heat flux is given by the formula:
+properties at exactly the interface (subscript $s$), while on the other, at infinity,
+is the virgin material (subscript $v$), the steady state heat flux is given by the formula:
 
-**q**_cond_ss = -**u**_r (&#961;_v h_v - &#961;_s h_s).
+$$
+\vec{q}_{cond,ss} = -\vec{u}_r (\rho_v h_v - \rho_s h_s).
+$$
 
 By replacing the formula above in the surface energy balance and after simplifications one gets:
 
-(&#961; ( **u**_g - **u**_r ) H + **q**_g + **u**_r &#961;_v h_v) . **n** = &#937;_e,
+$$
+[ \rho ( \vec{u}_g - \vec{u}_r ) H + \vec{q}_g + \vec{u}_r \rho_v h_v ] \cdot \hat{n} = \Omega_e,
+$$
 
 which is equally valid for both porous and non-porous materials. In order to use the steady state ablation
 approximation, the attribute of surface_feature element solid_conduction should be set to steady state.
-Instead of inputing the
+Instead of inputting the
 virgin material density, the ratio between the virgin and surface density minus one is often used,
 refered to as
-&#966; = (&#961;_v / &#961;_s - 1) and is the attribute
+$\varphi = (\frac{\rho_v}{\rho_s} - 1)$ and is the attribute
 virgin_to_surf_density_ratio in the solid_properties element defaulting to 1.
 The enthalpy_virgin can also be an input with default
 value equal to 0. Note that these two last options are only necessary when the steady
@@ -1468,15 +1509,15 @@ state assumption for the solid conduction is considered.
 
 When a material solver is available the conductive heat flux should be an input to the
 library for increased accuracy. This can be achieved by setting the solid_conduction
-surface feature to "input" and the setSolidCondHeatFlux function can be invoked.
+surface feature to `input` and the `setSolidCondHeatFlux` function can be invoked.
 The option enthalpy_surface should be set in this case, otherwise it is automatically set
 to zero.
 
 Note that only one surface balance equation is solved regardless of the thermodynamic
-state model. When multitemperature models are considered for the thermodynamics additional
+state model. When multi-temperature models are considered for the thermodynamics additional
 temperatures should be imposed on the surface. It is often a reasonable assumption to
 impose thermal equilibrium at the wall. This is achieved by setting the surface_feature
-option surface_in_thermal_equil "true". If it is "false", then any additional temperature
+option surface_in_thermal_equil `true`. If it is `false`, then any additional temperature
 beyond translations will be left unchanged, an assumption which can be used to impose an
 adiabatic boundary condition for the internal energy modes.
 
@@ -1498,7 +1539,7 @@ mechanism file.
 ```
 
 Below an example code of how to use the gas surface interaction features
-of Mutation is presented.
+of Mutation++ is presented.
 
 ```cpp
     const int set_state_with_rhoi_T = 1;

--- a/docs/input-files.md
+++ b/docs/input-files.md
@@ -20,6 +20,11 @@
   - [Unit Specifiers](#unit-specifiers)
   - [Example Mechanism](#example-mechanism)
 - [Collision Integral Database](#collision-integrals) (work in progress)
+  - [Introduction](#collisions_intro)
+  - [Defining collision pairs](#collisions_pairs)
+  - [Collision integral types](#collisions_types)
+  - [Global options](#collisions_global_options)
+  - [Species data](#collisions_species_data)
 - [Gas-Surface Interaction](#gsi)
   - [Surface Chemical Production Terms](#surf_chem)
     - [Carbon Oxidation Model](#coxid)
@@ -47,9 +52,9 @@ The data files distributed with Mutation++ are located in one of the subdirector
 ### File location
 <a id="file-location"></a>
 
-Mutation++ is aware of its `data_directory`. It defaults to the `MPP_DATA_DIRECTORY` environment variable, which should have been setup during the [installation](@ref installation) of Mutation++ and usually points to the aforementioned data directory.
+Mutation++ is aware of its `data_directory`. It defaults to the `MPP_DATA_DIRECTORY` environment variable, which should have been setup during the [installation](#installation) of Mutation++ and usually points to the aforementioned data directory.
 
-In addition, Mutation++ is aware of the `working_directory`, where an executable that utilizes Mutation++ is being run. [Mixture files](@ref mixtures) may also be in the working directory.
+In addition, Mutation++ is aware of the `working_directory`, where an executable that utilizes Mutation++ is being run. [Mixture files](#mixtures) may also be in the working directory.
 
 When a data file `name`.`ext` is requested, Mutation++ searches for it looking up locations in the following order:
 1. `working_directory`/`name`.`ext`
@@ -86,7 +91,7 @@ name followed by an equal sign and the value of the attribute in quotations.
 Between the tag and end-tag of an element, an element may also contain one or more _child elements_ or _text_ (but not both).  From the figure, the root element contains two child elements named `child1_tag` and `child2_tag`.  Note that the first child element is an example of an element which contains text instead of more child elements.  The second child element is an example of a short-hand format for elements which only contain attributes.  For such elements, a full end-tag is not necessary.  Instead, simply putting `/>` after the attribute list is sufficient to end the element.  Finally, _comments_ can be inserted anywhere outside of element tags.  Comment strings begin with `<!--` and end with `-->` and can be spread over multiple lines.
 
 
-## Mixtures 
+## Mixtures
 <a id="mixtures"></a>
 
 Mixture files are located in the `data/mixtures` directory.  They are the primary
@@ -126,7 +131,7 @@ names separated by white space as in the example mixture above.
 
 A species list can also contain a more generic descriptor which allows the user to
 choose species based on a given set of rules.  For now, the rule simply allows
-to choose all species in a particular category which contian certain elements from a
+to choose all species in a particular category which contain certain elements from a
 list.  The format for this descriptor is
 
 ```
@@ -305,43 +310,43 @@ N2                Ref-Elm. Gurvich,1978 pt1 p280 pt2 p207.
 ```xml
 <!-- Nitrogen diatomic -->
 <species name="N2">
-	<stoichiometry>
-		N: 2
-	</stoichiometry>
-	<thermodynamics type="RRHO">
-		<linear>
-			yes
-		</linear>
-		<rotational_temperature units="K">
-			2.886
-		</rotational_temperature>
-		<steric_factor>
-			2
-		</steric_factor>
-		<vibrational_temperatures units="K">
-			3408.464
-		</vibrational_temperatures>
-		<electronic_levels units="1/cm">
-			<level degeneracy="1" energy="0.0" />
-			<level degeneracy="3" energy="50203.5" />
-			<level degeneracy="6" energy="59619.2" />
-			<level degeneracy="6" energy="59808.0" />
-			<level degeneracy="3" energy="66272.5" />
-			<level degeneracy="1" energy="68152.7" />
-			<level degeneracy="2" energy="69283.0" />
-			<level degeneracy="2" energy="72097.6" />
-			<level degeneracy="5" energy="77600.0" />
-			<level degeneracy="1" energy="85200.0" />
-			<level degeneracy="6" energy="86800.0" />
-			<level degeneracy="6" energy="89136.7" />
-			<level degeneracy="10" energy="93000.0" />
-			<level degeneracy="6" energy="97603.0" />
-			<level degeneracy="6" energy="104600.0" />
-		</electronic_levels>
-		<formation_enthalpy T="298 K" P="1 atm" units="J/mol">
-			0.0
-		</formation_enthalpy>
-	</thermodynamics>
+    <stoichiometry>
+        N: 2
+    </stoichiometry>
+    <thermodynamics type="RRHO">
+        <linear>
+            yes
+        </linear>
+        <rotational_temperature units="K">
+            2.886
+        </rotational_temperature>
+        <steric_factor>
+            2
+        </steric_factor>
+        <vibrational_temperatures units="K">
+            3408.464
+        </vibrational_temperatures>
+        <electronic_levels units="1/cm">
+            <level degeneracy="1" energy="0.0" />
+            <level degeneracy="3" energy="50203.5" />
+            <level degeneracy="6" energy="59619.2" />
+            <level degeneracy="6" energy="59808.0" />
+            <level degeneracy="3" energy="66272.5" />
+            <level degeneracy="1" energy="68152.7" />
+            <level degeneracy="2" energy="69283.0" />
+            <level degeneracy="2" energy="72097.6" />
+            <level degeneracy="5" energy="77600.0" />
+            <level degeneracy="1" energy="85200.0" />
+            <level degeneracy="6" energy="86800.0" />
+            <level degeneracy="6" energy="89136.7" />
+            <level degeneracy="10" energy="93000.0" />
+            <level degeneracy="6" energy="97603.0" />
+            <level degeneracy="6" energy="104600.0" />
+        </electronic_levels>
+        <formation_enthalpy T="298 K" P="1 atm" units="J/mol">
+            0.0
+        </formation_enthalpy>
+    </thermodynamics>
 </species>
 ```
 
@@ -482,50 +487,53 @@ resulting mechanism file `example.xml` is given below.
 ## Collision Integral Database
 <a id="collision-integrals"></a>
 
-_This is a workin in progress._
+_This is a work in in progress._
 
-@section collisions_intro Introduction
+### Introduction
+<a id="collisions_intro"></a>
+
 The collision integral database is provided in the `data/transport/collisions.xml` file.
 This page documents how collision integral data is stored and configured.  In particular,
-- how to define [collision pairs](\ref collisions_pairs),
-- how to use different [collision integral models](\ref collisions_types),
-- how to tune the [default behavior](\ref collisions_defaults),
-- how to specify [global options](\ref collisions_global_options),
-- and finally, how to provide [species-specific data](\ref collisions_species_data) needed
+- how to define [collision pairs](#collisions_pairs),
+- how to use different [collision integral models](#collisions_types),
+- how to tune the [default behavior](#collisions_defaults),
+- how to specify [global options](#collisions_global_options),
+- and finally, how to provide [species-specific data](#collisions_species_data) needed
   for some collision integral models.
 
 All collision integral databases must be contained within a `collisions` XML element as
 follows.
-\code{xml}
+```xml
 <collisions>
     <!-- All data corresponding to collision pairs and integrals go here -->
 </collisions>
-\endcode
+```
 
-----
-@section collisions_pairs Defining collision pairs
+### Defining collision pairs
+<a id="collisions_pairs"></a>
+
 The most basic node type which can be given as a child of `collisions` is a `pair`
 node, which specifies an individual collision pair.
-\code{xml}
+```xml
 <pair s1="first species name" s2="second species name">
     <!-- Specify models for each collision integral kind here -->
 </pair>
-\endcode
+```
 The `pair` node has two attributes, `s1` and `s2`, which are the names of the two
 interacting species in the pair.  Child nodes can then be given which provide the
 data necessary to compute any of the collision integrals for that pair.  The format
 of the collision integral nodes is described next.
 
-----
-@section collisions_types Collision integral types
-Specific collision integral data are provided as XML nodes with the node tag as the 
-name of the collision integral kind.  For example, to specify the 
-\f$\overline{Q}^{(1,1)}\f$ integral for the N-O interaction pair, use
-\code{xml}
+### Collision integral types
+<a id="collisions_types"></a>
+
+Specific collision integral data are provided as XML nodes with the node tag as the
+name of the collision integral kind.  For example, to specify the $\overline{Q}^{(1,1)}$ integral for the N-O interaction pair, use
+```xml
 <pair s1="N" s2="O">
     <Q11 type="model" />
 </pair>
-\endcode
+```
 where the `type` attribute is the collision integral model to use.  The attributes and
 possible child nodes or text needed in the collision integral XML node depends on the
 type of model being used.
@@ -535,9 +543,9 @@ be found in the following subsections.
 
 type              | Description
 ------------------|------------
-`Bruno-Eq(11)`    | Implements the curve-fit found in Eq. (11) of \cite Bruno2010
-`Bruno-Eq(17)`    | Implements the curve-fit found in Eq. (17) of \cite Bruno2010
-`Bruno-Eq(19)`    | Implements the curve-fit found in Eq. (19) of \cite Bruno2010
+`Bruno-Eq(11)`    | Implements the curve-fit found in Eq. (11) of [Bruno et al. (2010)](bibliography.md#Bruno2010)
+`Bruno-Eq(17)`    | Implements the curve-fit found in Eq. (17) of [Bruno et al. (2010)](bibliography.md#Bruno2010)
+`Bruno-Eq(19)`    | Implements the curve-fit found in Eq. (19) of [Bruno et al. (2010)](bibliography.md#Bruno2010)
 `constant`        | Constant value
 `Debye-Huckel`    | Based on Debye-Huckel potential (Coulomb potential, screened by Debye length)
 `exp-poly`        | Exponential polynomial
@@ -545,30 +553,30 @@ type              | Description
 `from B*`         | Uses B* relationship to compute missing integral
 `from C*`         | Uses C* relationship to compute missing integral
 `Langevin`        | Based on the Langevin potential
-`Murphy`          | Implements Eq. (5) of \cite Murphy1995 for combining elastic and inelastic interactions
-`Pirani`          | Implements the Pirani potential, using the approximate curve-fits of Laricchiuta et al. \cite Laricchiuta2007
+`Murphy`          | Implements Eq. (5) of [Murphy (1995)](bibliography.md#Murphy1995) for combining elastic and inelastic interactions
+`Pirani`          | Implements the Pirani potential, using the approximate curve-fits of [Laricchiuta et al. (2007)](bibliography.md#Laricchiuta2007)
 `ratio`           | Ratio of another integral
 `table`           | Tabulated data
 `warning`         | Prints a warning if used
 
-Regardless of the `type`, all collision integral nodes can specify the following 
+Regardless of the `type`, all collision integral nodes can specify the following
 attributes.
 
 Attribute  | Description
 -----------|------------
 `accuracy` | The estimated accuracy of the integral in percent off true value
-`multpi`   | (`yes` or `no`) Should the integral be multipled by \f$\pi\f$?
+`multpi`   | (`yes` or `no`) Should the integral be multiplied by $\pi$?
 `ref`      | A reference for the data
 `units`    | The units of the integral provided by the data
 
 Note that while theoretically any name can be used as a tag for specifying collision
-integrals, the following names are reserved for use within the various transport 
+integrals, the following names are reserved for use within the various transport
 algorithms: `Q11`, `Q12`, `Q13`, `Q14`, `Q15`, `Q22`, `Q23`, `Q24`, `Ast`, `Bst`, and
 `Cst`.
 
 The following code snippet taken from the `collisions.xml` file provided with the library
 shows the specification of the collision integrals needed for the N2-N2 interaction.
-\code{xml}
+```xml
 <pair s1="N2" s2="N2">
     <Q11 type="table" units="K,Å-Å" multpi="yes" ref="Wright2005" accuracy="10">
             300   600  1000  2000  4000  6000  8000 10000,
@@ -577,271 +585,300 @@ shows the specification of the collision integrals needed for the N2-N2 interact
             300   600  1000  2000  4000  6000  8000 10000,
           13.72 11.80 10.94  9.82  8.70  8.08  7.58  7.32 </Q22>
 </pair>
-\endcode
+```
 
 Note that the values of B* and C* which are also need for the neutral-neutral interaction
-are not shown because they are specified through [default behaviour](\ref collisions_defaults).
+are not shown because they are specified through [default behaviour](#collisions_defaults).
 
-@subsection collision_types_bruno_11 Bruno-Eq(11)
-Implements the curve-fit found in Eq. (11) of Bruno et al. \cite Bruno2010,
-\f[
-\sigma^2\Omega^{(l,s)*} = 
+#### Bruno-Eq(11)
+<a id="collision_types_bruno_11"></a>
+
+Implements the curve-fit found in Eq. (11) of [Bruno et al. (2010)](bibliography.md#Bruno2010),
+$$
+\sigma^2\Omega^{(l,s)*} =
     [a_1 + a_2 x] \frac{\exp[(x-a_3)/a_4]}{\exp[(x-a_3)/a_4] + \exp[(a_3-x)/a_4]} +
     a_5 \frac{\exp[(x-a_6)/a_7]}{\exp[(x-a_6)/a_7] + \exp[(a_6-x)/a_7]},
-\f]
-where \f$a_i\f$ are given coefficients and \f$x = \ln(T)\f$.  The following code
+$$
+where $a_i$ are given coefficients and $x = \ln(T)$.  The following code
 snippet details how the 7 coefficients are provided in XML format.
-\code{xml}
+```xml
 <Q11 type="Bruno-Eq(11)">
-    15.09506044  -1.25710008   9.57839369  -3.80371463   
-     0.98646613   9.25705877  -0.93611707 
+    15.09506044  -1.25710008   9.57839369  -3.80371463
+     0.98646613   9.25705877  -0.93611707
 </Q11>
-\endcode
-        
-@subsection collision_types_bruno_17 Bruno-Eq(17)
-Implements the curve-fit found in Eq. (17) of Bruno et al. \cite Bruno2010 for
-modeling charge exchange interactions,
-\f[
-\sigma^2\Omega^{(l,s)*} = d_1 + d_2 x + d_3 x^2,
-\f]
-where \f$d_i\f$ are given coefficients and \f$x = \ln(T)\f$.  The following code
-snippet details how the 3 coefficients are provided in XML format.
-\code{xml}
-<Q11 type="Bruno-Eq(17)"> 6.3544e+01 -5.0093e+00  9.8797e-02 </Q11>
-\endcode
+```
 
-@subsection collision_types_bruno_19 Bruno-Eq(19)
-Implements the curve-fit found in Eq. (19) of Bruno et al. \cite Bruno2010 for
-modeling electron-neutral interactions,
-\f[
-\sigma^2\Omega^{(l,s)*} = 
+#### Bruno-Eq(17)
+<a id="collision_types_bruno_17"></a>
+
+Implements the curve-fit found in Eq. (17) of [Bruno et al. (2010)](bibliography.md#Bruno2010) for
+modeling charge exchange interactions,
+$$
+\sigma^2\Omega^{(l,s)*} = d_1 + d_2 x + d_3 x^2,
+$$
+where $d_i$ are given coefficients and $x = \ln(T)$.  The following code
+snippet details how the 3 coefficients are provided in XML format.
+```xml
+<Q11 type="Bruno-Eq(17)"> 6.3544e+01 -5.0093e+00  9.8797e-02 </Q11>
+```
+
+#### Bruno-Eq(19)
+<a id="collision_types_bruno_19"></a>
+
+Implements the curve-fit found in Eq. (19) of [Bruno et al. (2010)](bibliography.md#Bruno2010)
+for modeling electron-neutral interactions,
+$$
+\sigma^2\Omega^{(l,s)*} =
     g_3 x^{g_5} \frac{\exp[(x-g_1)/a_2]}{\exp[(x-g_1)/g_2] + \exp[(g_1-x)/g_2]} +
     g_6 \exp\big[-\big(\frac{x-g_7}{g_8}\big)^2\big] + g_4,
-\f]
-where \f$g_i\f$ are given coefficients and \f$x = \ln(T)\f$.  The following code
+$$
+where $g_i$ are given coefficients and $x = \ln(T)$. The following code
 snippet details how the 8 coefficients are provided in XML format.
-\code{xml}
+```xml
 <Q11 type="Bruno-Eq(19)">
-    1.035291134e+1 -1.583011620e+0 1.245844036e+1 -2.328519000e-1 
-    5.366285730e-2 -5.343729290e+0 9.355617520e+0 -2.154634270e+0 
+    1.035291134e+1 -1.583011620e+0 1.245844036e+1 -2.328519000e-1
+    5.366285730e-2 -5.343729290e+0 9.355617520e+0 -2.154634270e+0
 </Q11>
-\endcode
+```
 
-@subsection collision_types_constant constant
+#### constant
+<a id="collision_types_constant"></a>
+
 Uses a constant value for the collision integral.
-\code{xml}
+```xml
 <Q11 type="constant" value="1.0e-20"/>
-\endcode
+```
 
-@subsection collision_types_debye_huckel Debye-Huckel
+#### Debye-Huckel
+<a id="collision_types_debye_huckel"></a>
+
 Models interactions between charged particles using the screened Coulomb potential
 shielded by the Debye length, known as the Debye-Huckle potential.  The tables of
-precomputed collision integrals provided by Mason, Munn, and Smith \cite Mason1967
-and Devoto \cite Devoto1973 are used to implement the integrals.  The following
+precomputed collision integrals provided by [Mason, Munn, and Smith (1967)](bibliography.md#Mason1967)
+and [Devoto (1973)](bibliography.md#Devoto1973) are used to implement the integrals.  The following
 code snippet shows how to use this model.
-\code{xml}
+```xml
 <Q11 type="Debye-Huckel"/>
-\endcode
+```
 Note the actual value of the integral will depend on the kind of collision integral
 (or ratio) such as `Q11` or `Ast` and whether or not the interaction is repulsive
 or attractive.
 
-@subsection collision_types_exp_poly exp-poly
+#### exp-poly
+<a id="collision_types_exp_poly"></a>
+
 Implements an exponential polynomial curve-fit expression of the form
-\f[
+$$
 \overline{Q}^{(l,s)}_{i,j}(T) = \exp\big(\sum_{i=0}^{n-1} a_i x^i \big),
-\f]
-where \f$a_i\f$ are given coefficients and \f$x = \ln(T)\f$.  The following XML
+$$
+where $a_i$ are given coefficients and $x = \ln(T)$.  The following XML
 snippet shows how to format the coefficients in the database.
-\code{xml}
+```xml
 <Q11 type="exp-poly">
     -4.942712e-03 1.113337e-01 -9.844008e-01 6.435295e+00
 </Q11>
-\endcode
-Note that the **coefficients are given in reverse order** and any number of 
+```
+Note that the **coefficients are given in reverse order** and any number of
 coefficients can be used.
 
-@subsection collision_types_from_A from A*
-Uses relationship \f$ A^{*}_{ij} = \overline{Q}^{(2,2)}_{i,j} / 
-\overline{Q}^{(1,1)}_{i,j}\f$ to compute either \f$A^{*}_{ij}\f$, 
-\f$\overline{Q}^{(1,1)}_{i,j}\f$, or \f$\overline{Q}^{(2,2)}_{i,j}\f$, given
+#### from A*
+<a id="collision_types_from_A"></a>
+
+Uses relationship $ A^{*}_{ij} = \overline{Q}^{(2,2)}_{i,j} / \overline{Q}^{(1,1)}_{i,j}$
+to compute either $A^{*}_{ij}$,
+$\overline{Q}^{(1,1)}_{i,j}$, or $\overline{Q}^{(2,2)}_{i,j}$, given
 the other two.  Simply use the `from A*` type for the missing integral, as in
-\code{xml}
+```xml
 <Q11 type="from A*"/>
-\endcode
+```
 and provide concrete types for the other two.
 
-@subsection collision_types_from_B from B*
-Uses relationship \f$ B^{*}_{ij} = (5\overline{Q}^{(1,2)}_{i,j} - 4
-\overline{Q}^{(1,3)}_{i,j})/\overline{Q}^{(1,1)}_{i,j}\f$ to compute either 
-\f$B^{*}_{ij}\f$, \f$\overline{Q}^{(1,1)}_{i,j}\f$, \f$\overline{Q}^{(1,2)}_{i,j}\f$,
-or \f$\overline{Q}^{(1,3)}_{i,j}\f$, given the other three.  Simply use the `from B*` 
+#### from B*
+<a id="collision_types_from_B"></a>
+
+Uses relationship $ B^{*}_{ij} = (5\overline{Q}^{(1,2)}_{i,j} - 4 \overline{Q}^{(1,3)}_{i,j})/\overline{Q}^{(1,1)}_{i,j}$
+to compute either $B^{*}_{ij}$, $\overline{Q}^{(1,1)}_{i,j}$, $\overline{Q}^{(1,2)}_{i,j}$,
+or $\overline{Q}^{(1,3)}_{i,j}$, given the other three.  Simply use the `from B*`
 type for the missing integral, as in
-\code{xml}
+```xml
 <Q11 type="from B*"/>
-\endcode
+```
 and provide concrete types for the other three.
 
-@subsection collision_types_from_C from C*
-Uses relationship \f$ C^{*}_{ij} = \overline{Q}^{(1,2)}_{i,j} / 
-\overline{Q}^{(1,1)}_{i,j}\f$ to compute either \f$C^{*}_{ij}\f$, 
-\f$\overline{Q}^{(1,1)}_{i,j}\f$, or \f$\overline{Q}^{(1,2)}_{i,j}\f$, given
+#### from C*
+<a id="collision_types_from_C"></a>
+
+Uses relationship $ C^{*}_{ij} = \overline{Q}^{(1,2)}_{i,j} / \overline{Q}^{(1,1)}_{i,j}$
+to compute either $C^{*}_{ij}$, $\overline{Q}^{(1,1)}_{i,j}$, or $\overline{Q}^{(1,2)}_{i,j}$, given
 the other two.  Simply use the `from C*` type for the missing integral, as in
-\code{xml}
+```xml
 <Q11 type="from C*"/>
-\endcode
+```
 and provide concrete types for the other two.
 
-@subsection collision_types_langevin Langevin
-The Langevin (polarization) potential has been used extensively for modeling 
+#### Langevin
+<a id="collision_types_langevin"></a>
+
+The Langevin (polarization) potential has been used extensively for modeling
 ion-neutral interactions and represents a special case of the inverse power
 potential.  A closed form analytical solution of the collision integral using
 this potential is given as
-\f[
+$$
 \overline{Q}^{(l,s)}_{i,j} = C^{(l,s)} z \pi \sqrt{\frac{\alpha}{T}},
-\f]
-where \f$C^{(l,s)}\f$ is a constant depending on \f$l\f$ and \f$s\f$, \f$z\f$ is
-the elementary charge of the ion, and \f$\alpha\f$ is the dipole polarizability
+$$
+where $C^{(l,s)}$ is a constant depending on $l$ and $s$, $z$ is
+the elementary charge of the ion, and $\alpha$ is the dipole polarizability
 of the neutral.  An example is given in the following code snippet.
-\code{xml}
+```xml
 <Q11 type="Langevin">
-\endcode
-Note that the values of \f$l\f$ and \f$s\f$ are automatically determined from the
-kind of integral (in this case `Q11`) and \f$z\f$ is determined from the interaction
+```
+Note that the values of $l$ and $s$ are automatically determined from the
+kind of integral (in this case `Q11`) and $z$ is determined from the interaction
 pair that the integral is assigned to.  The dipole polarizability of the netural
-must be provided in a [polarizability table](@ref collisions_polarizabilities) 
+must be provided in a [polarizability table](#collisions_polarizabilities)
 somewhere in the database.
 
-@subsection collision_types_murphy Murphy
-Implements Eq. (5) of \cite Murphy1995 for combining elastic and inelastic
+#### Murphy
+<a id="collision_types_murphy"></a>
+
+Implements Eq. (5) of [Murphy (1995)](bibliography.md#Murphy1995) for combining elastic and inelastic
 interactions, where
-\f[
+$$
 \overline{Q}_{ij}^{(l,s)}(T) = \sqrt{Q_1(T)^2 + Q_2(T)^2}
-\f]
-where \f$Q_1\f$ and \f$Q_2\f$ are the elastic and
+$$
+where $Q_1$ and $Q_2$ are the elastic and
 inelastic parts.  This combination rule is often used for ion-parent
 interactions where charge exchange interactions become important.  The XML format is
 as follows.
-\code{xml}
+```xml
 <Q11 type="Murphy">
     <Q1 type="Bruno-Eq(11)">
-        46.68783791  -0.33303803   4.25686770  -2.03851201  
+        46.68783791  -0.33303803   4.25686770  -2.03851201
         14.98170958   8.59618369  -1.65616736 </Q1>
     <Q2 type="Bruno-Eq(17)">
         6.3544e+01 -5.0093e+00  9.8797e-02 </Q2>
 </Q11>
-\endcode
+```
 Note that the types of `Q1` and `Q2` can be any valid collision integral type.
 
-@subsection collision_types_pirani Pirani
-The phenomenological Pirani potential has been introduced in \cite Pirani2004, 
+#### Pirani
+<a id="collision_types_pirani"></a>
+
+The phenomenological Pirani potential has been introduced in [Pirani et al. (2004)](bibliography.md#Murphy1995),
 taking the form
-\f[
+$$
 \phi = \epsilon_0 \big[ \frac{m}{n(x)-m} \big(\frac{1}{x}\big)^{n(x)} -
 \frac{n(x)}{n(x)-m} \big(\frac{1}{x}\big)^{m} \big],
-\f]
-where \f$ x = r/r_e\f$ and \f$n(x) = \beta + 4x^2\f$.  For netural-neutral and
+$$
+where $ x = r/r_e$ and $n(x) = \beta + 4x^2$.  For netural-neutral and
 ion-neutral interactions, m has the value of 6 and 4, respectively.  The value
-of \f$\beta\f$ ranges from 6 to 10 depending on the "hardness" of the the 
-interacting electronic distribution densities and can be estimated as 
-\f[
+of $\beta$ ranges from 6 to 10 depending on the "hardness" of the the
+interacting electronic distribution densities and can be estimated as
+$$
 \beta = 6 + \frac{5}{s_1 + s_2},
-\f]
-where \f$s_1\f$ and \f$s_2\f$ are the softness values of the colliding partners
-1 and 2.  This is defined as the cubic root of the dipole polarizabilities of 
-the two species.  The remaining parameters, \f$r_e\f$ and \f$\epsilon_0\f$ must
+$$
+where $s_1$ and $s_2$ are the softness values of the colliding partners
+1 and 2.  This is defined as the cubic root of the dipole polarizabilities of
+the two species.  The remaining parameters, $r_e$ and $\epsilon_0$ must
 be either fit to match experimental observations or estimated based on correlations.
 Both options are available:
-\code{xml}
+```xml
 <!-- Option 1: provide necessary parameters -->
 <Q11 type="Pirani" beta="7.2644" eps0="0.00798" re="3.621" />
 
 <!-- Option 2: estimate parameters
 <Q11 type="Pirani" />
-\endcode
-Laricchiuta et al. \cite Laricchiuta2007 provide the necessary correlation
+```
+[Laricchiuta et al. (2007)](bibliography.md#Laricchiuta2007) provide the necessary correlation
 formulas for determining the missing parameters if option 2 is chosen.  The
-correlations rely on needing the [dipole polarizabilities](@ref collisions_polarizabilities) 
-of the interacting species and, for neutral-neutral interactions, the 
-[effective electrons](\ref collisions_effective_electrons) contributing to the 
+correlations rely on needing the [dipole polarizabilities](#collisions_polarizabilities)
+of the interacting species and, for neutral-neutral interactions, the
+[effective electrons](#collisions_effective_electrons) contributing to the
 polarization of the neutral species.
 
 Curve-fits of the collision integrals computed using the Pirani potential have
-been provided in \cite Laricchiuta2007.  These are used to evaluate collision
-integrals using this potential, automatically taking into account the type of
-interaction and integral.
+been provided in [Laricchiuta et al. (2007)](bibliography.md#Laricchiuta2007).
+These are used to evaluate collision integrals using this potential,
+automatically taking into account the type of interaction and integral.
 
-@subsection collision_types_ratio ratio
+#### ratio
+<a id="collision_types_ratio"></a>
+
 Use a ratio of another defined collision integral.
-\code{xml}
+```xml
 <Q22 type="ratio" ratio="1.1" integral="Q11" />
-\endcode
+```
 The XML syntax takes an integral name and the ratio to multiply that integral by. In this
 case `Q22` will be computed as 1.1 times `Q11`.
 
-@subsection collision_types_table table
+#### table
+<a id="collision_types_table"></a>
+
 Interpolates tabulated collision integral data.  The table is provided in XML as two
 space delimited lists, separated by a comma.
-\code{xml}
+```xml
 <Q11 type="table" units="K,Å-Å" interpolator="l=Linear" clip="yes">
     1000  2000  4000  5000  6000  8000 10000 15000 20000,
-    0.12  0.19  0.43  0.55  0.66  0.89  1.12  1.68  2.23 
+    0.12  0.19  0.43  0.55  0.66  0.89  1.12  1.68  2.23
 </Q11>
-\endcode
+```
 The first list indicates the temperature points and the second the collision integral
 values, with the units specified by the units attribute.  The `interpolator`
-attribute specifies which interpolator is used to interpolate on the table.  By 
+attribute specifies which interpolator is used to interpolate on the table.  By
 default, `Linear` is used if no interpolator is specified.  `Chebyshev` and
 `MonotoneCubic` may also be used.  The `clip` attribute specifies whether or not to
 clip the collision integral at the bounds of the table.  By default this is `yes`.
 
-@subsection collision_types_warning warning
+#### warning
+<a id="collision_types_warning"></a>
+
 Uses a constant value for the integral and prints a warning message.  This can be
 used when no data is available for a given species pair and kind of integral, without
 crashing.
-\code{xml}
-<Q11 type="warning" value="1.0e-20"/>  
-\endcode
+```xml
+<Q11 type="warning" value="1.0e-20"/>
+```
 
-----
-@section collisions_defaults Specifying default behavior
+### Specifying default behavior
+<a id="collisions_defaults"></a>
+
 Specifying collision integral data for every collision pair in your mixture may
 sound like a daunting task.  Chances are that most of the integrals you
 need are already provided in the database.  For the ones that aren't available
 already, the database provides a facility to specify default behavior by
 specifying the `defaults` node.
-\code{xml}
+```xml
 <!-- Default collision integral data -->
 <defaults>
     <!-- Neutral-Neutral interactions -->
     <neutral-neutral>
         <!-- Collision integral definitions -->
     </neutral-neutral>
-    
+
     <!-- Ion-Neutral interactions -->
     <ion-neutral>
         <!-- Collision integral definitions -->
     </ion-neutral>
-    
+
     <!-- Electron-Neutral interactions -->
     <electron-neutral>
         <!-- Collision integral definitions -->
     </electron-neutral>
-    
+
     <!-- Charged interactions -->
     <charged>
         <!-- Collision integral definitions -->
     </charged>
 </defaults>
-\endcode
+```
 
 The `defaults` node allows the user to configure how to provide default
-collision integrals for missing data, based on the four general types of 
+collision integrals for missing data, based on the four general types of
 interactions: neutral-neutral, ion-neutral, electron-neutral, and charged.
 Whenever the user requests to load a specific integral, the library will first
 search the database for the explicit collision pair/integral kind requested. If
-the pair or integral type is not found explicitely, the library will then resort
-to the default integral provided in `defaults`, according to the type of 
+the pair or integral type is not found explicitly, the library will then resort
+to the default integral provided in `defaults`, according to the type of
 interaction specified by the pair.  This approach has several benefits:
 - The default behavior is self-documenting and easily tunable without writing
 new code or recompiling the library
@@ -850,10 +887,10 @@ when data is missing
 - No extra work is required to add new species pairs if the default behavior is
 good enough.
 
-This last point is particularly valid in the case of charged interactions, for 
+This last point is particularly valid in the case of charged interactions, for
 which the screened Coulomb potential is nearly always a valid approximation.
 Therefore, all charged interaction pairs can be supported easily by setting
-\code{xml}
+```xml
 <defaults>
     <!-- Charged interactions -->
     <charged>
@@ -873,65 +910,69 @@ Therefore, all charged interaction pairs can be supported easily by setting
 
     <!-- Other interactions -->
 </defaults>
-\endcode
-Other cases can be envisaged as well.  For example, using the 
-[Langevin](@ref collision_types_langevin) model as default for all ion-neutral 
-interactions means that only the [dipole polarizability](\ref collisions_polarizabilities) 
+```
+Other cases can be envisaged as well.  For example, using the
+[Langevin](#collision_types_langevin) model as default for all ion-neutral
+interactions means that only the [dipole polarizability](#collisions_polarizabilities)
 of the neutral species needs to be specified to add a new ion-neutral pair.
 
-----
-@section collisions_global_options Global options
+
+### Global options
+<a id="collisions_global_options"></a>
+
 The `global-options` node specifies options that act on the whole collision
 integral database.  For the moment, there are only two options that can be set.
-\code{xml}
+```xml
 <global-options>
     <tabulate Tmin="100" Tmax="50000" dT="100" />
     <integral type="table" interpolator="Linear" clip="true"/>
 </global-options>
-\endcode
+```
 
 The `tabulate` option instructs the database manager to tabulate all collision
 integrals after loading them.  The temperature grid used in the tabulation is
 specified through the `Tmin`, `Tmax`, and `dT` attributes which are the minimum
 and maximum temperatures, and the constant temperature spacing, respectively.
 
-The second option shown, `integral`, is used to specify global options for a 
+The second option shown, `integral`, is used to specify global options for a
 specific collision integral type.  In the example, the default `interoplator`
-and `clip` attributes for all [table](\ref collision_types_table) collision 
-integrals are set to `Linear` and `true` respectively.  Note that for the moment, 
-only attributes of [table](\ref collision_types_table) can be specified in this
+and `clip` attributes for all [table](#collision_types_table) collision
+integrals are set to `Linear` and `true` respectively.  Note that for the moment,
+only attributes of [table](#collision_types_table) can be specified in this
 way.
 
-----
-@section collisions_species_data Species data
+### Species data
+<a id="collisions_species_data"></a>
+
 Some of the collision integral models detailed above require additional information
 about individual species, such as their dipole polarizabilities.  These parameters are
-stored in generic XML nodes as children of the root `collisions` element, with the 
+stored in generic XML nodes as children of the root `collisions` element, with the
 following general structure.
-\code{xml}
+```xml
 <species-property units="some units">
     <species name="some name" value="some value" ref="some reference" units="other units" />
     <species name="some name" value="some value" ref="some reference" />
     <species name="some name" value="some value" ref="some reference" />
 </species-property>
-\endcode
-Here, `species-property` denotes the name of the spcies property stored in the node.
+```
+Here, `species-property` denotes the name of the species property stored in the node.
 Default units can be given as shown in the `units` attribute of the `species-property`
 node.  The property node then contains child nodes for each individual species for which
 data is provided.  Those nodes provide the species `name`, the `value` of the property
 for that species, an optional `ref` attribute for attributing a reference for the data,
-and the possibility to override the default `units`.  
+and the possibility to override the default `units`.
 
 __A note for developers:__ Species properties stored in this
-way can be easily found in any child class of Mutation::Transport::CollisionIntegral by 
-calling the Mutation::Transport::CollisionIntegral::loadSpeciesParameter() function.
+way can be easily found in any child class of `Mutation::Transport::CollisionIntegral` by calling the `Mutation::Transport::CollisionIntegral::loadSpeciesParameter()` function.
 
-@subsection collisions_polarizabilities Dipole polarizabilities
+#### Dipole polarizabilities
+<a id="collisions_polarizabilities"></a>
+
 Species dipole polarizabilities are used as inputs to some collision integral models,
-including [Langevin](@ref collision_types_langevin) and 
-[Pirani](@ref collision_types_pirani).  An example listing of dipole polarizabilities
+including [Langevin](#collision_types_langevin) and
+[Pirani](#collision_types_pirani).  An example listing of dipole polarizabilities
 is given below.
-\code{xml}
+```xml
 <!-- Dipole Polarizabilities -->
 <dipole-polarizabilities units="Å-Å-Å">
     <species name="N"    value="1.10"   ref="Wright2007"/>
@@ -940,14 +981,16 @@ is given below.
     <species name="O"    value="0.80"   ref="Wright2007"/>
     <species name="O2"   value="1.58"   ref="Wright2007"/>
 </dipole-polarizabilities>
-\endcode
+```
 
-@subsection collisions_effective_electrons Number of effective electrons in polarization
+#### Number of effective electrons in polarization
+<a id="collisions_effective_electrons"></a>
+
 The number of effective electrons in the polarization of a given species is used
-in the [Pirani](@ref collision_types_pirani) collision integral model.  These
+in the [Pirani](#collision_types_pirani) collision integral model.  These
 values are stored in the species database `effective-electrons`, following the
 example below.
-\code{xml}
+```xml
 <effective-electrons>
     <species name="C"    value="4.0"   />
     <species name="C2"   value="6.00"  />
@@ -955,14 +998,14 @@ example below.
     <species name="C2H2" value="10.00" />
     <species name="C2H4" value="12.00" />
 </effective-electrons>
-\endcode
+```
 The value of the effective electrons for new species can be estimated using the
-approach of Cambi et al. \cite Cambi1991.
+approach of [Cambi (1991)](bibliography.md#Cambi1991).
 
 ## Gas-Surface Interaction
 <a id="gsi"></a>
 
-The gas-surface interaction module of Mutation++ is responsinble for
+The gas-surface interaction module of Mutation++ is responsible for
 treating chemically reacting surfaces in thermochemical non-equilibrium.
 With the aim to obtain the appropriate surface boundary conditions
 for a chemically reacting gas, the conservation equations on the
@@ -1294,7 +1337,7 @@ reactions during which the dissociated atoms in the flow field recombine directl
 thermal protection system, which by burning protects the vehicle. Contrary to catalysis, this
 burning destroys the material itself making it unable for reuse. Not only chemical reactions can
 cause the degradation of ablative thermal protection systems. Mechanical removal processes, such
-as spillation, can also occur. The particle injected in the flow field due to these phenomena are
+as spallation, can also occur. The particle injected in the flow field due to these phenomena are
 not necessarily in a gaseous form and their modeling requires approaches beyond the scope of this
 work. The type of chemical reactions studied here are assumed to produce only gaseous species
 and occur only the surface of the material. In cases where the material is porous, ablation

--- a/docs/input-files.md
+++ b/docs/input-files.md
@@ -271,7 +271,7 @@ Constants                                               | Format       | Columns
 Species name                                            | `A24`        | `1-24`
 Comments (data source)                                  | `A56`        | `25-80`
 <b>Line 2</b>                                           | -            | -
-Number of T intervals                             | `I2`         | `2`
+Number of T intervals                                   | `I2`         | `2`
 Optional identification code                            | `A6`         | `4-9`
 Chemical formulas, symbols, and numbers                 | `5(A2,F6.2)` | `11-50`
 Zero for gas, nonzero for condensed phases              | `I1`         | `52`
@@ -279,14 +279,14 @@ Molecular weight                                        | `F13.5`      | `53-65`
 Heat of formation at 298.15 K, J/mol                    | `F13.5`      | `66-80`
 <b>Line 3</b>                                           | -            | -
 Temperature range                                       | `2F10.3`     | `2-21`
-Number of coefficients for C_p^\circ/R_u          | `I1`         | `23`
-T exponents in polynomial for C_p^\circ/R_u | `8F5.1`      | `24-63`
-H^\circ (298.15)-H^\circ (0), J/mol               | `F15.3`      | `66-80`
+Number of coefficients for $`C_p^\circ/R_u`$            | `I1`         | `23`
+T exponents in polynomial for $`C_p^\circ/R_u`$         | `8F5.1`      | `24-63`
+$`H^\circ (298.15)-H^\circ (0)`$, J/mol                 | `F15.3`      | `66-80`
 <b>Line 4</b>                                           | -            | -
-First five coefficients for C_p^\circ/R_u         | `5F16.8`     | `1-80`
+First five coefficients for $`C_p^\circ/R_u`$           | `5F16.8`     | `1-80`
 <b>Line 5</b>                                           | -            | -
-Last three coefficients for C_p^\circ/R_u         | `3F16.8`     | `1-48`
-Integration constants  b_1  and  b_2        | `2F16.8`     | `49-80`
+Last three coefficients for $`C_p^\circ/R_u`$           | `3F16.8`     | `1-48`
+Integration constants  b_1  and  b_2                    | `2F16.8`     | `49-80`
 <i>Repeat 3, 4, and 5 for each interval...</i>          | -            | -
 
 
@@ -401,14 +401,14 @@ when evaluating the forward rate coefficient.  The rate law node is specified by
 and its corresponding attributes correspond to the parameters for that given rate law.  The
 following rate rate laws are currently supported.
 
-- `arrhenius`  k(T) = A T<sup>n</sup> exp[-Ea / (Ru T)]
+- `arrhenius`  $`k(T) = A\, T^n\, \exp \left( \frac{-E_a}{R_u T} \right)`$
 
 Att. | Value
 -----|--------
 `A`  | pre-exponential factor
 `n`  | temperature exponent
 `Ea` | activation energy
-`T`  | characteristic temperature Ea / Ru
+`T`  | characteristic temperature $`E_a / R_u`$
 
 _note: only one of `Ea` or `T` may be used, not both_
 
@@ -439,7 +439,7 @@ controlled by an Arrhenius rate law.
 
 \# | Formula                                  | A [mol,cm,s,K] | n     | Ea [K]
 ---|------------------------------------------|----------------|-------|--------
-1  | N2 + N2 <-> 2N + N2    | 1.0e21         | -1.6  | 113200
+1  | N2 + N2 <-> 2N + N2     | 1.0e21         | -1.6  | 113200
 2  | N2 + N <-> 2N + N       | 3.0e21         | -1.6  | 113200
 3  | N2 + N^+ <-> 2N + N+    | 1.0e21         | -1.6  | 113200
 4  | N2 + e- <-> 2N + e-     | 7.0e22         | -1.6  | 113200
@@ -528,7 +528,7 @@ of the collision integral nodes is described next.
 <a id="collisions_types"></a>
 
 Specific collision integral data are provided as XML nodes with the node tag as the
-name of the collision integral kind.  For example, to specify the $\overline{Q}^{(1,1)}$ integral for the N-O interaction pair, use
+name of the collision integral kind.  For example, to specify the $`\overline{Q}^{(1,1)}``$integral for the N-O interaction pair, use
 ```xml
 <pair s1="N" s2="O">
     <Q11 type="model" />
@@ -565,7 +565,7 @@ attributes.
 Attribute  | Description
 -----------|------------
 `accuracy` | The estimated accuracy of the integral in percent off true value
-`multpi`   | (`yes` or `no`) Should the integral be multiplied by $\pi$?
+`multpi`   | (`yes` or `no`) Should the integral be multiplied by $`\pi`$?
 `ref`      | A reference for the data
 `units`    | The units of the integral provided by the data
 
@@ -594,12 +594,12 @@ are not shown because they are specified through [default behaviour](#collisions
 <a id="collision_types_bruno_11"></a>
 
 Implements the curve-fit found in Eq. (11) of [Bruno et al. (2010)](bibliography.md#Bruno2010),
-$$
+```math
 \sigma^2\Omega^{(l,s)*} =
     [a_1 + a_2 x] \frac{\exp[(x-a_3)/a_4]}{\exp[(x-a_3)/a_4] + \exp[(a_3-x)/a_4]} +
     a_5 \frac{\exp[(x-a_6)/a_7]}{\exp[(x-a_6)/a_7] + \exp[(a_6-x)/a_7]},
-$$
-where $a_i$ are given coefficients and $x = \ln(T)$.  The following code
+```
+where $`a_i`$ are given coefficients and $`x = \ln(T)`$.  The following code
 snippet details how the 7 coefficients are provided in XML format.
 ```xml
 <Q11 type="Bruno-Eq(11)">
@@ -613,10 +613,10 @@ snippet details how the 7 coefficients are provided in XML format.
 
 Implements the curve-fit found in Eq. (17) of [Bruno et al. (2010)](bibliography.md#Bruno2010) for
 modeling charge exchange interactions,
-$$
+```math
 \sigma^2\Omega^{(l,s)*} = d_1 + d_2 x + d_3 x^2,
-$$
-where $d_i$ are given coefficients and $x = \ln(T)$.  The following code
+```
+where $`d_i`$ are given coefficients and $`x = \ln(T)`$.  The following code
 snippet details how the 3 coefficients are provided in XML format.
 ```xml
 <Q11 type="Bruno-Eq(17)"> 6.3544e+01 -5.0093e+00  9.8797e-02 </Q11>
@@ -627,12 +627,12 @@ snippet details how the 3 coefficients are provided in XML format.
 
 Implements the curve-fit found in Eq. (19) of [Bruno et al. (2010)](bibliography.md#Bruno2010)
 for modeling electron-neutral interactions,
-$$
+```math
 \sigma^2\Omega^{(l,s)*} =
     g_3 x^{g_5} \frac{\exp[(x-g_1)/a_2]}{\exp[(x-g_1)/g_2] + \exp[(g_1-x)/g_2]} +
     g_6 \exp\big[-\big(\frac{x-g_7}{g_8}\big)^2\big] + g_4,
-$$
-where $g_i$ are given coefficients and $x = \ln(T)$. The following code
+```
+where $`g_i`$ are given coefficients and $`x = \ln(T)`$. The following code
 snippet details how the 8 coefficients are provided in XML format.
 ```xml
 <Q11 type="Bruno-Eq(19)">
@@ -668,10 +668,10 @@ or attractive.
 <a id="collision_types_exp_poly"></a>
 
 Implements an exponential polynomial curve-fit expression of the form
-$$
+```math
 \overline{Q}^{(l,s)}_{i,j}(T) = \exp\big(\sum_{i=0}^{n-1} a_i x^i \big),
-$$
-where $a_i$ are given coefficients and $x = \ln(T)$.  The following XML
+```
+where $`a_i`$ are given coefficients and $`x = \ln(T)`$.  The following XML
 snippet shows how to format the coefficients in the database.
 ```xml
 <Q11 type="exp-poly">
@@ -684,9 +684,9 @@ coefficients can be used.
 #### from A*
 <a id="collision_types_from_A"></a>
 
-Uses relationship $ A^{*}_{ij} = \overline{Q}^{(2,2)}_{i,j} / \overline{Q}^{(1,1)}_{i,j}$
-to compute either $A^{*}_{ij}$,
-$\overline{Q}^{(1,1)}_{i,j}$, or $\overline{Q}^{(2,2)}_{i,j}$, given
+Uses relationship $`A^{*}_{ij} = \overline{Q}^{(2,2)}_{i,j} / \overline{Q}^{(1,1)}_{i,j}`$
+to compute either $`A^{*}_{ij}`$,
+$`\overline{Q}^{(1,1)}_{i,j}`$, or $`\overline{Q}^{(2,2)}_{i,j}`$, given
 the other two.  Simply use the `from A*` type for the missing integral, as in
 ```xml
 <Q11 type="from A*"/>
@@ -696,9 +696,9 @@ and provide concrete types for the other two.
 #### from B*
 <a id="collision_types_from_B"></a>
 
-Uses relationship $ B^{*}_{ij} = (5\overline{Q}^{(1,2)}_{i,j} - 4 \overline{Q}^{(1,3)}_{i,j})/\overline{Q}^{(1,1)}_{i,j}$
-to compute either $B^{*}_{ij}$, $\overline{Q}^{(1,1)}_{i,j}$, $\overline{Q}^{(1,2)}_{i,j}$,
-or $\overline{Q}^{(1,3)}_{i,j}$, given the other three.  Simply use the `from B*`
+Uses relationship $`B^{*}_{ij} = (5\overline{Q}^{(1,2)}_{i,j} - 4 \overline{Q}^{(1,3)}_{i,j})/\overline{Q}^{(1,1)}_{i,j}`$
+to compute either $`B^{*}_{ij}`$, $`\overline{Q}^{(1,1)}_{i,j}`$, $`\overline{Q}^{(1,2)}_{i,j}`$,
+or $`\overline{Q}^{(1,3)}_{i,j}`$, given the other three.  Simply use the `from B*`
 type for the missing integral, as in
 ```xml
 <Q11 type="from B*"/>
@@ -708,8 +708,8 @@ and provide concrete types for the other three.
 #### from C*
 <a id="collision_types_from_C"></a>
 
-Uses relationship $ C^{*}_{ij} = \overline{Q}^{(1,2)}_{i,j} / \overline{Q}^{(1,1)}_{i,j}$
-to compute either $C^{*}_{ij}$, $\overline{Q}^{(1,1)}_{i,j}$, or $\overline{Q}^{(1,2)}_{i,j}$, given
+Uses relationship $`C^{*}_{ij} = \overline{Q}^{(1,2)}_{i,j} / \overline{Q}^{(1,1)}_{i,j}`$
+to compute either $`C^{*}_{ij}`$, $`\overline{Q}^{(1,1)}_{i,j}`$, or $`\overline{Q}^{(1,2)}_{i,j}`$, given
 the other two.  Simply use the `from C*` type for the missing integral, as in
 ```xml
 <Q11 type="from C*"/>
@@ -723,18 +723,18 @@ The Langevin (polarization) potential has been used extensively for modeling
 ion-neutral interactions and represents a special case of the inverse power
 potential.  A closed form analytical solution of the collision integral using
 this potential is given as
-$$
+```math
 \overline{Q}^{(l,s)}_{i,j} = C^{(l,s)} z \pi \sqrt{\frac{\alpha}{T}},
-$$
-where $C^{(l,s)}$ is a constant depending on $l$ and $s$, $z$ is
-the elementary charge of the ion, and $\alpha$ is the dipole polarizability
-of the neutral.  An example is given in the following code snippet.
+```
+where $`C^{(l,s)}`$ is a constant depending on $`l`$ and $`s`$, $`z`$ is
+the elementary charge of the ion, and $`\alpha`$ is the dipole polarizability
+of the neutral. An example is given in the following code snippet.
 ```xml
 <Q11 type="Langevin">
 ```
-Note that the values of $l$ and $s$ are automatically determined from the
-kind of integral (in this case `Q11`) and $z$ is determined from the interaction
-pair that the integral is assigned to.  The dipole polarizability of the netural
+Note that the values of $`l`$ and $`s`$ are automatically determined from the
+kind of integral (in this case `Q11`) and $`z`$ is determined from the interaction
+pair that the integral is assigned to.  The dipole polarizability of the neutral
 must be provided in a [polarizability table](#collisions_polarizabilities)
 somewhere in the database.
 
@@ -743,10 +743,10 @@ somewhere in the database.
 
 Implements Eq. (5) of [Murphy (1995)](bibliography.md#Murphy1995) for combining elastic and inelastic
 interactions, where
-$$
+```math
 \overline{Q}_{ij}^{(l,s)}(T) = \sqrt{Q_1(T)^2 + Q_2(T)^2}
-$$
-where $Q_1$ and $Q_2$ are the elastic and
+```
+where $`Q_1`$ and $`Q_2`$ are the elastic and
 inelastic parts.  This combination rule is often used for ion-parent
 interactions where charge exchange interactions become important.  The XML format is
 as follows.
@@ -766,20 +766,20 @@ Note that the types of `Q1` and `Q2` can be any valid collision integral type.
 
 The phenomenological Pirani potential has been introduced in [Pirani et al. (2004)](bibliography.md#Murphy1995),
 taking the form
-$$
+```math
 \phi = \epsilon_0 \big[ \frac{m}{n(x)-m} \big(\frac{1}{x}\big)^{n(x)} -
 \frac{n(x)}{n(x)-m} \big(\frac{1}{x}\big)^{m} \big],
-$$
-where $ x = r/r_e$ and $n(x) = \beta + 4x^2$.  For netural-neutral and
+```
+where $`x = r/r_e`$ and $`n(x) = \beta + 4x^2`$. For neutral-neutral and
 ion-neutral interactions, m has the value of 6 and 4, respectively.  The value
-of $\beta$ ranges from 6 to 10 depending on the "hardness" of the the
+of $`\beta`$ ranges from 6 to 10 depending on the "hardness" of the the
 interacting electronic distribution densities and can be estimated as
-$$
+```math
 \beta = 6 + \frac{5}{s_1 + s_2},
-$$
-where $s_1$ and $s_2$ are the softness values of the colliding partners
+```
+where $`s_1`$ and $`s_2`$ are the softness values of the colliding partners
 1 and 2.  This is defined as the cubic root of the dipole polarizabilities of
-the two species.  The remaining parameters, $r_e$ and $\epsilon_0$ must
+the two species.  The remaining parameters, $`r_e`$ and $`\epsilon_0`$ must
 be either fit to match experimental observations or estimated based on correlations.
 Both options are available:
 ```xml
@@ -1029,14 +1029,14 @@ three dimensional fluxes reduce to the normal fluxes at the interface while the 
 source terms, such as chemical reactions, go to zero; only the surface sources remain.
 Generally, the set of balance equations can be written as:
 
-$$
+```math
 (\vec{F}_g - \vec{F}_b) \cdot \hat{n} = \Omega_s,
-$$
+```
 
-where $\vec{F}$ are the fluxes from the gas ($g$) and the bulk ($b$) phases, while
-$\Omega$ are the source terms associated to the surface ($s$) processes.
+where $`\vec{F}`$ are the fluxes from the gas ($`g`$) and the bulk ($`b`$) phases, while
+$`\Omega`$ are the source terms associated to the surface ($`s`$) processes.
 Only the normal to surface flux component should be considered, denoted by
-the inner product of the flux with the surface unit vector, ($\hat{n}$).
+the inner product of the flux with the surface unit vector, ($`\hat{n}`$).
 The specific form of the balance equations for mass and energy will be seen in the following
 sections.
 
@@ -1063,46 +1063,46 @@ modeled with the $\gamma$ (gamma) model, with reaction probability equal to 1.
 </gsi>
 ```
 
-The $\gamma$ model, introduced by Goulard in the late 1950s, is arguably the most popular
+The $`\gamma`$ model, introduced by Goulard in the late 1950s, is arguably the most popular
 way to treat catalysis in the aero-thermodynamics community. It describes catalytic
 reactions as macroscopic, non-elementary processes of the form:
 
-$$
+```math
 \mathrm{A} + \mathrm{A} \to \mathrm{A_2}
-$$
+```
 
 In order to determine the chemical production term for this kind of catalytic reactions a
-probability for recombination $\gamma$ is defined for each recombining species A as:
+probability for recombination $`\gamma`$ is defined for each recombining species A as:
 
-$$
+```math
 \gamma = F_{rec} / F_{imp},
-$$
+```
 
-where $F_{imp}$ is the flux of species A impinging the surface and
-$F_{rec}$ is the flux of species recombining at the surface. This probability is
-the input parameter for the model. A fully catalytic wall has $\gamma$ equal to 1, which
+where $`F_{imp}`$ is the flux of species A impinging the surface and
+$`F_{rec}`$ is the flux of species recombining at the surface. This probability is
+the input parameter for the model. A fully catalytic wall has $`\gamma`$ equal to 1, which
 means that all the particles of species A impinging the surface recombine at the wall.
-$\gamma$ equal to 0 means that no reaction takes place and corresponds
+$`\gamma`$ equal to 0 means that no reaction takes place and corresponds
 to a non catalytic, or chemically inert wall. Anything between these two extreme cases is a
 partially catalytic wall, which is the case for most of the surfaces. When the probability
-$\gamma$ is defined, the surface chemical source term is determined as:
+$`\gamma`$ is defined, the surface chemical source term is determined as:
 
-$$
+```math
 \begin{align}
 \Omega_A &= \gamma m_A F_{imp} \\
 \Omega_{A2} &= - \gamma m_A F_{imp}
 \end{align}
-$$
+```
 
-with $m_A$ being the mass of species A.
+with $`m_A`$ being the mass of species A.
 
 The only parameter that still needs to be defined is the impinging flux on the surface.
 When the distribution function of species at the wall is well approximated by a Maxwellian
-and there is no temperature slip, the impinging flux, $F_{imp}$, is equal to
+and there is no temperature slip, the impinging flux, $`F_{imp}`$, is equal to
 
-$$
+```math
 F_{imp} = n_A \sqrt{\frac{k_B T}{2 \pi m_A}}
-$$
+```
 
 according to the kinetic theory of gases.
 
@@ -1111,35 +1111,35 @@ such as the one presented in above.
 Soon, though, it was observed that heteronuclear reactions were also probable
 to occur at the wall, which can take the form of
 
-$$
+```math
 \mathrm{A} + \mathrm{B} \to \mathrm{AB},
-$$
+```
 
 with the chemical rate for the produced molecule AB equal to:
 
-$$
+```math
 \Omega_{AB}  = - \gamma_{AB} m_A F_{imp,A} - \gamma_{BA} m_B F_{imp,B}.
-$$
+```
 
 One atom of A recombines with one atom of B on the surface to produce a molecule AB.
 In other words the number of atoms of A that recombine into AB should be equal to the number of B
 atoms that recombine into AB. This restriction should be explicitly imposed in order to conserve mass:
 
-$$
+```math
 \gamma_{AB} F_{imp,A} = \gamma_{BA} F_{imp,B}.
-$$
+```
 
 As a result, in a reaction of this type two gamma recombination coefficients should be defined not
 necessarily equal for the two processes, the one activated when the catalytic reaction is limited by the
 flux of A atoms and the opposite. In practice the two recombination number fluxes,
-$\gamma_{AB} F_{imp,A}$ and $\gamma_{BA} F_{imp,B}$, are compared and the limiting one
+$`\gamma_{AB} F_{imp,A}`$ and $`\gamma_{BA} F_{imp,B}`$, are compared and the limiting one
 determines which of the two gammas is chosen.
 
 These gamma coefficients cannot take arbitrary values, they should be limited between 0 and 1,
 just like in the homonuclear case. When extra catalytic reactions are added,
-such as $\mathrm{A} + \mathrm{A} \to \mathrm{A_2}$ and $\mathrm{B} + \mathrm{B} \to \mathrm{B_2}$,
+such as $`\mathrm{A} + \mathrm{A} \to \mathrm{A_2}`$ and $`\mathrm{B} + \mathrm{B} \to \mathrm{B_2}`$,
 the gammas should be further constrained
-as $0 \lt \gamma_A + \gamma_{AB} \lt 1$ and $0 \lt \gamma_B + \gamma_{BA} \lt 1$
+as $`0 \lt \gamma_A + \gamma_{AB} \lt 1`$ and $`0 \lt \gamma_B + \gamma_{BA} \lt 1`$
 in order for mass to be conserved. This approach is consistent with similar approaches
 considering the catalytic recombination occurring in Martian atmospheres, where O can recombine
 into both O2 and CO2 due to catalytic reactions.
@@ -1256,21 +1256,21 @@ An example of ablation model can be seen below.
 The first ablation reaction presented above is the oxidation
 of the solid carbon by atomic oxygen. The reaction reads as:
 
-$$
+```math
 \mathrm{C}_b + \mathrm{O} \to \mathrm{CO}
-$$
+```
 
 and is exothermic, releasing 3.74 eV per molecule produced. Its reaction
 rate coefficient is given by defining a recombination probability
-$\gamma_{CO}$. This probability is an Arrhenius type function of temperature
+$`\gamma_{CO}`$. This probability is an Arrhenius type function of temperature
 and is given by the formula:
 
-$$
+```math
 \gamma_{CO} = 0.63 \exp \left(\frac{-1160~\mathrm{K}}{T} \right).
-$$
+```
 
 Carbon oxidation with molecular oxygen is also possible
-($\mathrm{C}_b + \mathrm{O_2} \to \mathrm{CO} + \mathrm{O}$),
+($`\mathrm{C}_b + \mathrm{O_2} \to \mathrm{CO} + \mathrm{O}`$),
 but it is often considered as a less significant process.
 
 #### Carbon Nitridation Model
@@ -1278,13 +1278,13 @@ but it is often considered as a less significant process.
 
 The second shown in the example is carbon nitridation,
 
-$$
+```math
 \mathrm{C}_b + \mathrm{N} \to \mathrm{CN}
-$$
+```
 
 an exothermic reaction with 0.35 eV of energy released per reacting atom.
 The reaction rate is given using a constant recombination probability
-$\gamma_{CN}$ like in the catalytic case.
+$`\gamma_{CN}`$ like in the catalytic case.
 
 #### Carbon Sublimation Model
 <a id="csubl"></a>
@@ -1293,25 +1293,25 @@ At high temperatures carbon removal from the surface is dominated by phase
 change processes like sublimation. The production of C3 is considered here.
 It should be noted that this type of reactions are invertible, with formula:
 
-$$
+```math
 3\mathrm{C}_b \to \mathrm{C_3}
-$$
+```
 
 The chemical production rate of this reaction is equal to:
 
-$$
+```math
 \Omega_{C_3} = \beta (\rho_{eq,C_3} - \rho_{C_3}) \sqrt{\frac{k_B T}{2 \pi m}}.
-$$
+```
 
 The equilibrium partial density of the C3 species is obtained from the
 saturated vapor pressure of carbon, which is equal to
 
-$$
-p_{sat,C_3} = c \exp \left( \frac{-Ta}{T} \right)
-$$
+```math
+p_{sat,C_3} = c \exp \left( \frac{-T_a}{T} \right)
+```
 
-with &#946_C3 being the evaporation coefficient, c the pre-exponential coefficient,
-and Ta the activation temperature.
+with $`\beta`$ being the evaporation coefficient, $`c`$ the pre-exponential coefficient,
+and $`T_a`$ the activation temperature.
 Even though here only sublimation is presented in the example, evaporation processes
 can be considered with the same model.
 
@@ -1342,9 +1342,9 @@ If all of the phenomena above are modeled with accuracy, the re-entry heat load 
 and the size of the thermal protection system can be determined.
 The mass balance on a catalytic surface reads:
 
-$$
+```math
 \vec{j}_i \cdot \hat{n} = \Omega_{cat,i},
-$$
+```
 
 where one mass balance equation should be solved for each distinct species in the flow.
 The equation above states, that the catalytic activity of every species is equal to the diffusion
@@ -1375,16 +1375,16 @@ processes also in the bulk, such as in the case of pyrolysis.
 
 Taking these ideas in mind, the surface mass balance accounting only for surface reactions becomes:
 
-$$
+```math
 [\rho_i (\vec{u}_g - \vec{u}_r) + \vec{j}_i - \vec{F}_{b,i} ] \cdot \hat{n} = \Omega_i,
-$$
+```
 
-with $\Omega_i = \Omega_{cat,i} + \Omega_{abl,i}$ and
-term $\vec{F}_{b,i}$ is the flux of species $i$ entering the interface due
+with $`\Omega_i = \Omega_{cat,i} + \Omega_{abl,i}`$ and
+term $`\vec{F}_{b,i}`$ is the flux of species $`i`$ entering the interface due
 to solid process, like pyrolysis and solid-solid chemical reactions.
 Just like before, one mass balance equation should be solved for each distinct species in the flow.
 It is most of the time reasonable to consider that recession velocity is
-orders of magnitude lower than the gas velocity $\vec{u}_r$.
+orders of magnitude lower than the gas velocity $`\vec{u}_r`$.
 
 ### Surface Energy Balance
 <a id="seb"></a>
@@ -1392,29 +1392,29 @@ orders of magnitude lower than the gas velocity $\vec{u}_r$.
 In order to determine the surface temperature a surface energy balance should be solved along
 with the mass balances. It takes the form:
 
-$$
+```math
 [ \rho ( \vec{u}_g - \vec{u}_r ) H + \vec{q}_g - \vec{F}_{b,e} ] \cdot \hat{n} = \Omega_e
-$$
+```
 
-where $\vec{q}_g$ is the heat flux to the gas phase equal to:
+where $`\vec{q}_g`$ is the heat flux to the gas phase equal to:
 
-$$
+```math
 \vec{q}_g = -\lambda \nabla T + \sum_i \vec{j}_i h_i.
-$$
+```
 
 The radiative heat flux can be also included and will be discussed along with the surface
 radiation.
 
-Term $\vec{F}_{b,e}$ describes the energy exchanged between the interface
+Term $`\vec{F}_{b,e}`$ describes the energy exchanged between the interface
 and the bulk of the solid and is composed of three contributions: the first one is the
-thermal conduction exiting the surface $\vec{q}_{cond}$, the second one is the
+thermal conduction exiting the surface $`\vec{q}_{cond}`$, the second one is the
 enthalpy entering the interface due to the movement of the surface with the recession velocity,
-$\vec{u}_r \rho h_s$ and the third one appears only in cases of
+$`\vec{u}_r \rho h_s`$ and the third one appears only in cases of
 porous material, describing the enthalpy of the solid pyrolysis gases convected in the interface,
-denoted as $\vec{u}_p \rho_p h_p$. The subscript $p$ symbolizes
-the pyrolysis gas properties, with the $\rho_p h_p$ being actually the
-sum $\sum_i = \rho_i h_i$ for the pyrolysis gas densities. The surface
-enthalpy $h_s$ is an input to the code, as an attribute to the surface_properties element.
+denoted as $`\vec{u}_p \rho_p h_p`$. The subscript $`p`$ symbolizes
+the pyrolysis gas properties, with the $`\rho_p h_p`$ being actually the
+sum $`\sum_i = \rho_i h_i`$ for the pyrolysis gas densities. The surface
+enthalpy $`h_s`$ is an input to the code, as an attribute to the surface_properties element.
 
 An example input file for solving both mass and energy balance can be seen below.
 ```xml
@@ -1464,14 +1464,14 @@ example above is radiation. It is considered by adding a new element with tag
 `<surface_radiation/>`. The surface is assumed to be in thermodynamic equilibrium
 at a temperature T emitting energy following the Stefan-Boltzmann law,
 
-$$
+```math
 \Omega_e = \Omega_{rad} = \epsilon ( \sigma T^4 - \vec{q}_{rad,g})
-$$
+```
 
-with $\sigma$ being the Stefan-Boltzmann constant and $\epsilon$ the emissivity
-of the surface. $T_{env}$ is the surrounding environment temperature which can
+with $`\sigma`$ being the Stefan-Boltzmann constant and $`\epsilon`$ the emissivity
+of the surface. $`T_{env}`$ is the surrounding environment temperature which can
 be used to simulate the far field radiative heat flux based on the formula
- $\sigma T_{env}^4$, which replaces the term $\vec{q}_{rad,g}$.
+$`\sigma T_{env}^4`$, which replaces the term $`\vec{q}_{rad,g}`$.
 This is a relatively bad approximation and, therefore, it is better to be omitted.
 
 In order to obtain the value for the conductive heat flux on the solid,
@@ -1483,25 +1483,25 @@ the simulations. Such an approximation was adopted here for the modeling of the
 conductive heat flux inside the material, the steady-state ablation approach for a
 semi-infinite surface. By writing the steady-state energy equation for the solid phase
 and integrating over the semi-infinite material, where on one side is the solid
-properties at exactly the interface (subscript $s$), while on the other, at infinity,
-is the virgin material (subscript $v$), the steady state heat flux is given by the formula:
+properties at exactly the interface (subscript $`s`$), while on the other, at infinity,
+is the virgin material (subscript $`v`$), the steady state heat flux is given by the formula:
 
-$$
+```math
 \vec{q}_{cond,ss} = -\vec{u}_r (\rho_v h_v - \rho_s h_s).
-$$
+```
 
 By replacing the formula above in the surface energy balance and after simplifications one gets:
 
-$$
+```math
 [ \rho ( \vec{u}_g - \vec{u}_r ) H + \vec{q}_g + \vec{u}_r \rho_v h_v ] \cdot \hat{n} = \Omega_e,
-$$
+```
 
 which is equally valid for both porous and non-porous materials. In order to use the steady state ablation
 approximation, the attribute of surface_feature element solid_conduction should be set to steady state.
 Instead of inputting the
 virgin material density, the ratio between the virgin and surface density minus one is often used,
 refered to as
-$\varphi = (\frac{\rho_v}{\rho_s} - 1)$ and is the attribute
+$`\varphi = (\frac{\rho_v}{\rho_s} - 1)`$ and is the attribute
 virgin_to_surf_density_ratio in the solid_properties element defaulting to 1.
 The enthalpy_virgin can also be an input with default
 value equal to 0. Note that these two last options are only necessary when the steady


### PR DESCRIPTION
- Cleans up formatting in collision integral docs.
- Adds bibliography entries.
- Fixes dead CEA link.
- Replaces unicode math with LaTeX whenever possible.