### PR TITLE
Closes #250. Make constants `constexpr`. Closes #251. Adds S-B constant.

### DIFF
--- a/src/general/Constants.h
+++ b/src/general/Constants.h
@@ -38,22 +38,22 @@ namespace Mutation {
 
 /// \defgroup math Mathematical constants
 /// @{
-const double PI    = 4.0 * std::atan(1.0); //!< \f$\pi\f$
-const double TWOPI = 2.0 * PI;             //!< \f$2\pi\f$
-const double SQRT2  = std::sqrt(2.0);      //!< \f$\sqrt{2}\f$
+constexpr double PI    = 3.14159265358979323846; //!< \f$\pi\f$
+constexpr double TWOPI = 2.0 * PI;               //!< \f$2\pi\f$
+constexpr double SQRT2 = 1.41421356237309504880; //!< \f$\sqrt{2}\f$
 /// @}
 
 /// \defgroup physical Physical constants (all units in SI)
 /// @{
-const double NA     = 6.0221415E23;    //!< Avagadro's number (molecule/mol)
-const double KB     = 1.3806503E-23;   //!< Boltzmann's constant (J/molecule-K)
-const double RU     = NA * KB;         //!< Universal Gas constant (J/mole-K)
-const double HP     = 6.626068E-34;    //!< Planck's constant (J-s)
-const double MU0    = PI * 4.0E-7;     //!< Magnetic constant (H/m)
-const double C0     = 299792458.0;     //!< Speed of light in vacuum (m/s)
-const double EPS0   = 1.0/(MU0*C0*C0); //!< Vacuum permittivity (F/m)
-const double QE     = 1.602176565E-19; //!< Elementary positive charge (C)
-const double ONEATM = 101325.0;        //!< 1 atm in Pa
+constexpr double NA     = 6.0221415E23;    //!< Avogadro's number (molecule/mol)
+constexpr double KB     = 1.3806503E-23;   //!< Boltzmann's constant (J/molecule-K)
+constexpr double RU     = NA * KB;         //!< Universal Gas constant (J/mole-K)
+constexpr double HP     = 6.626068E-34;    //!< Planck's constant (J-s)
+constexpr double MU0    = PI * 4.0E-7;     //!< Magnetic constant (H/m)
+constexpr double C0     = 299792458.0;     //!< Speed of light in vacuum (m/s)
+constexpr double EPS0   = 1.0/(MU0*C0*C0); //!< Vacuum permittivity (F/m)
+constexpr double QE     = 1.602176565E-19; //!< Elementary positive charge (C)
+constexpr double ONEATM = 101325.0;        //!< 1 atm in Pa
 /// @}
 
 /// @}

--- a/src/general/Constants.h
+++ b/src/general/Constants.h
@@ -54,6 +54,8 @@ constexpr double C0     = 299792458.0;     //!< Speed of light in vacuum (m/s)
 constexpr double EPS0   = 1.0/(MU0*C0*C0); //!< Vacuum permittivity (F/m)
 constexpr double QE     = 1.602176565E-19; //!< Elementary positive charge (C)
 constexpr double ONEATM = 101325.0;        //!< 1 atm in Pa
+constexpr double SB     = (2.0*PI*PI*PI*PI*PI*KB*KB*KB*KB)
+                        / (15.0*HP*HP*HP*C0*C0); //!< Stefan-Boltzmann constant (W/m^2-K^4)
 /// @}
 
 /// @}

--- a/src/gsi/SurfaceRadiation.cpp
+++ b/src/gsi/SurfaceRadiation.cpp
@@ -25,7 +25,7 @@
  * <http://www.gnu.org/licenses/>.
  */
 
-
+#include "Constants.h"
 #include "Thermodynamics.h"
 #include "Utilities.h"
 
@@ -49,9 +49,7 @@ SurfaceRadiation::SurfaceRadiation(
            m_gas_rad_heat_flux(0.),
            is_gas_rad_on(gas_rad_on),
            pos_E(thermo.nSpecies()),
-           pos_T_trans(0),
-           m_stef_bolt_const(2. * pow(PI, 5.0) * pow(KB, 4.0) /
-                (15. * pow(HP, 3.0) * pow(C0, 2.0)))
+           pos_T_trans(0)
 {
     xml_surf_rad.getAttribute("emissivity", m_eps,
         "Error in the surface radiation input. Surface emissivity "
@@ -59,7 +57,7 @@ SurfaceRadiation::SurfaceRadiation(
     xml_surf_rad.getAttribute("T_env", m_T_env, 0.);
 
     if (!is_gas_rad_on)
-        m_gas_rad_heat_flux = m_stef_bolt_const * std::pow(m_T_env, 4.0);
+        m_gas_rad_heat_flux = Mutation::SB * std::pow(m_T_env, 4.0);
 }
 
 //==============================================================================
@@ -71,8 +69,7 @@ SurfaceRadiation::~SurfaceRadiation(){}
 double SurfaceRadiation::surfaceNetRadiativeHeatFlux()
 {
     double T_surf = (m_surf_state.getSurfaceT())(pos_T_trans);
-    return m_eps * (m_stef_bolt_const * std::pow(T_surf, 4.0)
-        - m_gas_rad_heat_flux);
+    return m_eps * (Mutation::SB * std::pow(T_surf, 4.0) - m_gas_rad_heat_flux);
 }
 
     } // namespace GasSurfaceInteraction

--- a/src/gsi/SurfaceRadiation.h
+++ b/src/gsi/SurfaceRadiation.h
@@ -93,8 +93,6 @@ private:
     double m_T_env;
     double m_gas_rad_heat_flux;
 
-    const double m_stef_bolt_const;
-
     const SurfaceState& m_surf_state;
 };
 

--- a/tests/c++/test_gsi_mass_energy.cpp
+++ b/tests/c++/test_gsi_mass_energy.cpp
@@ -101,10 +101,9 @@ TEST_CASE("Solution of the MassEnergyBalanceSolver is converged.", "[gsi]")
         mix.surfaceReactionRates(wdot.data());
 
         // Surface radiation
-        const double sigma = 2.*pow(PI, 5)*pow(KB, 4)/(15*pow(C0, 2)*pow(HP, 3));
         const double eps = 1.;
         VectorXd q_srad = VectorXd::Zero(nT) ;
-        q_srad(pos_T_trans) = sigma * eps * pow(T_s(pos_T_trans), 4);
+        q_srad(pos_T_trans) = Mutation::SB * eps * pow(T_s(pos_T_trans), 4);
 
         // Building balance functions
         VectorXd F(neq);
@@ -190,10 +189,9 @@ TEST_CASE("Solution of the MassEnergyBalanceSolver is converged.", "[gsi]")
         v_h(pos_T_trans) = rhoi_s.dot(v_hi.head(ns));
 
         // Surface radiation
-        const double sigma = 2.*pow(PI, 5)*pow(KB, 4)/(15*pow(C0, 2)*pow(HP, 3));
         const double eps = .86;
         VectorXd q_srad = VectorXd::Zero(nT);
-        q_srad(pos_T_trans) = sigma*eps*pow(T_s(pos_T_trans), 4);
+        q_srad(pos_T_trans) = Mutation::SB*eps*pow(T_s(pos_T_trans), 4);
 
         // Chemical Energy Contribution
         VectorXd v_hi_rhoi_vi= VectorXd::Zero(nT);
@@ -288,10 +286,9 @@ TEST_CASE("Solution of the MassEnergyBalanceSolver is converged.", "[gsi]")
         v_h(pos_T_trans) = (rhoi_s/rho).dot(v_hi.head(ns));
 
         // Surface radiation
-        const double sigma = 2.*pow(PI, 5)*pow(KB, 4)/(15*pow(C0, 2)*pow(HP, 3));
         const double eps = .86;
         VectorXd q_srad = VectorXd::Zero(nT);
-        q_srad(pos_T_trans) = sigma*eps*pow(T_s(pos_T_trans), 4);
+        q_srad(pos_T_trans) = Mutation::SB*eps*pow(T_s(pos_T_trans), 4);
 
         // Chemical Energy Contribution
         VectorXd v_hi_rhoi_vi= VectorXd::Zero(nT);
@@ -388,9 +385,8 @@ TEST_CASE("Solution of the MassEnergyBalanceSolver is converged.", "[gsi]")
         double h = (rhoi_s/rho).dot(v_hi.head(ns));
 
         // Surface radiation
-        const double sigma = 2.*pow(PI, 5)*pow(KB, 4)/(15*pow(C0, 2)*pow(HP, 3));
         const double eps = .86;
-        double q_srad = sigma*eps*pow(T_s(pos_T_trans), 4);
+        double q_srad = Mutation::SB*eps*pow(T_s(pos_T_trans), 4);
 
         // Chemical Energy Contribution
         double v_hi_rhoi_vi = -v_hi.head(ns).dot(rhoi_s.cwiseProduct(vdi));


### PR DESCRIPTION
Closes #250. Make constants `constexpr` in `Constants.h` instead of just `const`.

Closes #251. Adds Stefan-Boltzmann constant to `Constants.h`.