### PR TITLE
Closes #253. Add missing include for `cwrapper.h`.

### DIFF
--- a/interface/fortran/cwrapper.h
+++ b/interface/fortran/cwrapper.h
@@ -28,6 +28,8 @@
 #ifndef FORTRAN_CWRAPPER_H
 #define FORTRAN_CWRAPPER_H
 
+#include <stdbool.h>
+
 // Converts the base function name in mpp_function(_) where the (_) represents
 // the name mangling that is performed in order to use the function in Fortran
 #define NAME_MANGLE(__name__) mpp_##__name__##_


### PR DESCRIPTION
Add a missing include for `cwrapper.h`.
`stdbool.h` header is needed for `bool` in pure C.

See #253. Closes #253.