### PR TITLE
Closes #303. Adds functions to get surface emissivity and radiative heat flux.

### DIFF
--- a/src/gsi/GasSurfaceInteraction.cpp
+++ b/src/gsi/GasSurfaceInteraction.cpp
@@ -216,6 +216,12 @@ void GasSurfaceInteraction::getMassBlowingRate(double& mdot){
 
 //==============================================================================
 
+void GasSurfaceInteraction::getRadiativeHeatFlux(double& qrad){
+    qrad = mp_surf->radiativeHeatFlux();
+}
+
+//==============================================================================
+
 inline void GasSurfaceInteraction::errorWrongTypeofGSIFile(
     const std::string& gsi_root_tag)
 {

--- a/src/gsi/GasSurfaceInteraction.cpp
+++ b/src/gsi/GasSurfaceInteraction.cpp
@@ -222,6 +222,12 @@ void GasSurfaceInteraction::getRadiativeHeatFlux(double& qrad){
 
 //==============================================================================
 
+void GasSurfaceInteraction::getSurfaceEmissivity(double& eps){
+    eps = mp_surf->surfaceEmissivity();
+}
+
+//==============================================================================
+
 inline void GasSurfaceInteraction::errorWrongTypeofGSIFile(
     const std::string& gsi_root_tag)
 {

--- a/src/gsi/GasSurfaceInteraction.h
+++ b/src/gsi/GasSurfaceInteraction.h
@@ -186,6 +186,13 @@ public:
      */
     void getRadiativeHeatFlux(double& qrad);
 
+    /**
+     * Function which returns the surface emissivity.
+     *
+     * @param eps on return surface emissivity
+     */
+    void getSurfaceEmissivity(double& eps);
+
 private:
     /**
      * Error function; wrong type of Gas Surface Interaction input file.

--- a/src/gsi/GasSurfaceInteraction.h
+++ b/src/gsi/GasSurfaceInteraction.h
@@ -179,6 +179,13 @@ public:
      */
     void getMassBlowingRate(double& mdot);
 
+    /**
+     * Function which returns the total radiative flux.
+     *
+     * @param qrad on return radiative heat flux W/m^2
+     */
+    void getRadiativeHeatFlux(double& qrad);
+
 private:
     /**
      * Error function; wrong type of Gas Surface Interaction input file.

--- a/src/gsi/Surface.h
+++ b/src/gsi/Surface.h
@@ -195,6 +195,18 @@ public:
 
 //==============================================================================
 
+    /**
+     * Purely virtual function returning the net radiative heat flux.
+     */
+    virtual double radiativeHeatFlux()
+    {
+        throw LogicError()
+        << "radiativeHeatFlux can be called only when solving "
+        << "the surface energy balance!";
+    }
+
+//==============================================================================
+
 };
 
     } // namespace GasSurfaceInteraction

--- a/src/gsi/Surface.h
+++ b/src/gsi/Surface.h
@@ -207,6 +207,18 @@ public:
 
 //==============================================================================
 
+    /**
+     * Purely virtual function returning the surface emissivity.
+     */
+    virtual double surfaceEmissivity()
+    {
+        throw LogicError()
+        << "emissivity can be called only when solving "
+        << "the surface energy balance!";
+    }
+
+//==============================================================================
+
 };
 
     } // namespace GasSurfaceInteraction

--- a/src/gsi/SurfaceBalanceSolverMassEnergy.cpp
+++ b/src/gsi/SurfaceBalanceSolverMassEnergy.cpp
@@ -250,6 +250,15 @@ public:
 
 //==============================================================================
 
+    double surfaceEmissivity()
+    {
+        if (mp_surf_rad != NULL)
+            return mp_surf_rad->surfaceEmissivity();
+        return 0.;
+    }
+
+//==============================================================================
+
     void updateFunction(Eigen::VectorXd& v_X)
     {
         applyTolerance(v_X);

--- a/src/gsi/SurfaceBalanceSolverMassEnergy.cpp
+++ b/src/gsi/SurfaceBalanceSolverMassEnergy.cpp
@@ -241,6 +241,15 @@ public:
 
 //==============================================================================
 
+    double radiativeHeatFlux()
+    {
+        if (mp_surf_rad != NULL)
+            return mp_surf_rad->surfaceNetRadiativeHeatFlux();
+        return 0.;
+    }
+
+//==============================================================================
+
     void updateFunction(Eigen::VectorXd& v_X)
     {
         applyTolerance(v_X);

--- a/src/gsi/SurfaceRadiation.cpp
+++ b/src/gsi/SurfaceRadiation.cpp
@@ -72,5 +72,12 @@ double SurfaceRadiation::surfaceNetRadiativeHeatFlux()
     return m_eps * (Mutation::SB * std::pow(T_surf, 4.0) - m_gas_rad_heat_flux);
 }
 
+//==============================================================================
+
+double SurfaceRadiation::surfaceEmissivity()
+{
+    return m_eps;
+}
+
     } // namespace GasSurfaceInteraction
 } // namespace Mutation

--- a/src/gsi/SurfaceRadiation.h
+++ b/src/gsi/SurfaceRadiation.h
@@ -75,6 +75,12 @@ public:
 
 //==============================================================================
     /**
+     *  Function which returns the surface emissivity.
+     */
+    double surfaceEmissivity();
+
+//==============================================================================
+    /**
      *  Function which takes the incoming radiative heat from the gas .
      */
     void gasRadiativeHeatFlux(const double& gas_rad_heat_flux){


### PR DESCRIPTION
Closes #303. Adds functions to get surface emissivity and radiative heat flux to the mixture object. Only valid in cases with GSI solving energy balance.