### PR TITLE
Closes #305. Add ability to set GSI solver convergence tolerance from mixture object

### DIFF
--- a/src/gsi/GasSurfaceInteraction.cpp
+++ b/src/gsi/GasSurfaceInteraction.cpp
@@ -210,6 +210,13 @@ void GasSurfaceInteraction::setIterationsSurfaceBalance(const int& iter)
 
 //==============================================================================
 
+void GasSurfaceInteraction::setWriteConvergenceSurfaceBalance(const bool flag)
+{
+    mp_surf->setWriteConvergenceSurfaceBalance(flag);
+}
+
+//==============================================================================
+
 void GasSurfaceInteraction::getMassBlowingRate(double& mdot){
     mdot = mp_surf->massBlowingRate();
 }

--- a/src/gsi/GasSurfaceInteraction.cpp
+++ b/src/gsi/GasSurfaceInteraction.cpp
@@ -217,6 +217,13 @@ void GasSurfaceInteraction::setWriteConvergenceSurfaceBalance(const bool flag)
 
 //==============================================================================
 
+void GasSurfaceInteraction::setConvergenceToleranceSurfaceBalance(const double& tol)
+{
+    mp_surf->setConvergenceToleranceSurfaceBalance(tol);
+}
+
+//==============================================================================
+
 void GasSurfaceInteraction::getMassBlowingRate(double& mdot){
     mdot = mp_surf->massBlowingRate();
 }

--- a/src/gsi/GasSurfaceInteraction.h
+++ b/src/gsi/GasSurfaceInteraction.h
@@ -173,6 +173,12 @@ public:
     void setIterationsSurfaceBalance(const int& iter);
 
     /**
+     * Function which allows to report convergence history for Newton solves.
+     * Default is false.
+     */
+    void setWriteConvergenceSurfaceBalance(const bool flag);
+
+    /**
      * Function which return the total mass blowing flux.
      *
      * @param mdot on return mass blowing flux kg/(m^2-s)

--- a/src/gsi/GasSurfaceInteraction.h
+++ b/src/gsi/GasSurfaceInteraction.h
@@ -179,6 +179,12 @@ public:
     void setWriteConvergenceSurfaceBalance(const bool flag);
 
     /**
+     * Function which allows to set convergence tolerance for Newton solves.
+     * Default value is 1e-8.
+     */
+    void setConvergenceToleranceSurfaceBalance(const double& tol);
+
+    /**
      * Function which return the total mass blowing flux.
      *
      * @param mdot on return mass blowing flux kg/(m^2-s)

--- a/src/gsi/Surface.h
+++ b/src/gsi/Surface.h
@@ -201,6 +201,19 @@ public:
 //==============================================================================
 
     /**
+     * Purely virtual function to be called to set the tolerance
+     * parameter for the Newton solver.
+     */
+    virtual void setConvergenceToleranceSurfaceBalance(const double& tol)
+    {
+        throw LogicError()
+        << "setConvergenceToleranceSurfaceBalance can be called only when solving "
+        << "the surface energy balance!";
+    }
+
+//==============================================================================
+
+    /**
      * Purely virtual function returning the total mass blowing flux
      * due to surface and bulk phase processes.
      */

--- a/src/gsi/Surface.h
+++ b/src/gsi/Surface.h
@@ -188,6 +188,19 @@ public:
 //==============================================================================
 
     /**
+     * Purely virtual function to be called to set the flag to output
+     * convergence history for the Newton solver.
+     */
+    virtual void setWriteConvergenceSurfaceBalance(const bool flag)
+    {
+        throw LogicError()
+        << "setWriteConvergenceSurfaceBalance can be called only when solving "
+        << "the surface energy balance!";
+    }
+
+//==============================================================================
+
+    /**
      * Purely virtual function returning the total mass blowing flux
      * due to surface and bulk phase processes.
      */

--- a/src/gsi/SurfaceBalanceSolverMass.cpp
+++ b/src/gsi/SurfaceBalanceSolverMass.cpp
@@ -196,6 +196,13 @@ public:
 
 //==============================================================================
 
+    void setConvergenceToleranceSurfaceBalance(const double& tol)
+    {
+        setEpsilon(tol);
+    }
+
+//==============================================================================
+
     double massBlowingRate() {
         return mp_mass_blowing_rate->computeBlowingFlux();
     }

--- a/src/gsi/SurfaceBalanceSolverMass.cpp
+++ b/src/gsi/SurfaceBalanceSolverMass.cpp
@@ -189,6 +189,13 @@ public:
 
 //==============================================================================
 
+    void setWriteConvergenceSurfaceBalance(const bool flag)
+    {
+        setWriteConvergenceHistory(flag);
+    }
+
+//==============================================================================
+
     double massBlowingRate() {
         return mp_mass_blowing_rate->computeBlowingFlux();
     }

--- a/src/gsi/SurfaceBalanceSolverMassEnergy.cpp
+++ b/src/gsi/SurfaceBalanceSolverMassEnergy.cpp
@@ -239,6 +239,13 @@ public:
 
 //==============================================================================
 
+    void setConvergenceToleranceSurfaceBalance(const double& tol)
+    {
+        setEpsilon(tol);
+    }
+
+//==============================================================================
+
     double massBlowingRate()
     {
         if (mp_surf_chem != NULL)

--- a/src/gsi/SurfaceBalanceSolverMassEnergy.cpp
+++ b/src/gsi/SurfaceBalanceSolverMassEnergy.cpp
@@ -232,6 +232,13 @@ public:
 
 //==============================================================================
 
+    void setWriteConvergenceSurfaceBalance(const bool flag)
+    {
+        setWriteConvergenceHistory(flag);
+    }
+
+//==============================================================================
+
     double massBlowingRate()
     {
         if (mp_surf_chem != NULL)


### PR DESCRIPTION
Closes #305. Add ability to set GSI solver convergence tolerance from mixture object.
Also adds the ability to set the write convergence flag for the GSI solver.